### PR TITLE
[Feature/#37] 피드 바텀시트 구현

### DIFF
--- a/PIMO/Sources/Model/Base/BottomSheetType.swift
+++ b/PIMO/Sources/Model/Base/BottomSheetType.swift
@@ -1,0 +1,14 @@
+//
+//  BottomSheetType.swift
+//  PIMO
+//
+//  Created by 김영인 on 2023/03/21.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import Foundation
+
+enum BottomSheetType {
+    case me
+    case other
+}

--- a/PIMO/Sources/View/Archive/ArchiveStore.swift
+++ b/PIMO/Sources/View/Archive/ArchiveStore.swift
@@ -37,6 +37,7 @@ struct ArchiveStore: ReducerProtocol {
     struct State: Equatable {
         @BindingState var path: [ArchiveScene] = []
         @BindingState var isShowToast: Bool = false
+        @BindingState var isBottomSheetPresented = false
         var toastMessage: ToastModel = ToastModel(title: PIMOStrings.textCopyToastTitle,
                                                   message: PIMOStrings.textCopyToastMessage)
         var archiveType: ArchiveType = .myArchive
@@ -49,6 +50,7 @@ struct ArchiveStore: ReducerProtocol {
         var feed: FeedStore.State?
         var friends: FriendsListStore.State?
         var setting: SettingStore.State?
+        var bottomSheet: BottomSheetStore.State?
         var audioPlayingFeedId: Int?
     }
     
@@ -67,6 +69,7 @@ struct ArchiveStore: ReducerProtocol {
         case feedDetail(FeedStore.Action)
         case friends(FriendsListStore.Action)
         case setting(SettingStore.Action)
+        case bottomSheet(BottomSheetStore.Action)
     }
     
     @Dependency(\.archiveClient) var archiveClient
@@ -116,6 +119,9 @@ struct ArchiveStore: ReducerProtocol {
                 case let .copyButtonDidTap(text):
                     pasteboard.string = text
                     state.isShowToast = true
+                case let .moreButtonDidTap(id):
+                    state.isBottomSheetPresented = true
+                    state.bottomSheet = BottomSheetStore.State(bottomSheetType: .me)
                 case .audioButtonDidTap:
                     guard let feedId = state.audioPlayingFeedId else {
                         state.audioPlayingFeedId = id
@@ -128,9 +134,17 @@ struct ArchiveStore: ReducerProtocol {
                 default:
                     break
                 }
-            case let .feedDetail(.copyButtonDidTap(text)):
-                pasteboard.string = text
-                state.isShowToast = true
+            case let .feedDetail(action):
+                switch action {
+                case let .copyButtonDidTap(text):
+                    pasteboard.string = text
+                    state.isShowToast = true
+                case let .moreButtonDidTap(id):
+                    state.isBottomSheetPresented = true
+                    state.bottomSheet = BottomSheetStore.State(bottomSheetType: .me)
+                default:
+                    break
+                }
             case .topBarButtonDidTap:
                 if state.archiveType == .myArchive {
                     // TODO: 내 피드 공유 (딥링크)
@@ -153,6 +167,15 @@ struct ArchiveStore: ReducerProtocol {
                 state.feedsType = type
                 state.feed = nil
                 TTSManager.shared.stopPlaying()
+            case let .bottomSheet(action):
+                switch action {
+                case .editButtonDidTap:
+                    state.isBottomSheetPresented = false
+                case .deleteButtonDidTap:
+                    state.isBottomSheetPresented = false
+                case .declationButtonDidTap:
+                    state.isBottomSheetPresented = false
+                }
             case let .feedDidTap(feed):
                 state.feed = FeedStore.State(
                     textImage: feed.textImages[0],
@@ -175,6 +198,9 @@ struct ArchiveStore: ReducerProtocol {
         }
         .ifLet(\.friends, action: /Action.friends) {
             FriendsListStore()
+        }
+        .ifLet(\.bottomSheet, action: /Action.bottomSheet) {
+            BottomSheetStore()
         }
         .forEach(\.feeds, action: /Action.feed(id:action:)) {
             FeedStore()

--- a/PIMO/Sources/View/Archive/ArchiveStore.swift
+++ b/PIMO/Sources/View/Archive/ArchiveStore.swift
@@ -121,7 +121,7 @@ struct ArchiveStore: ReducerProtocol {
                     state.isShowToast = true
                 case let .moreButtonDidTap(id):
                     state.isBottomSheetPresented = true
-                    state.bottomSheet = BottomSheetStore.State(bottomSheetType: .me)
+                    state.bottomSheet = BottomSheetStore.State(feedId: id, bottomSheetType: .me)
                 case .audioButtonDidTap:
                     guard let feedId = state.audioPlayingFeedId else {
                         state.audioPlayingFeedId = id
@@ -141,7 +141,7 @@ struct ArchiveStore: ReducerProtocol {
                     state.isShowToast = true
                 case let .moreButtonDidTap(id):
                     state.isBottomSheetPresented = true
-                    state.bottomSheet = BottomSheetStore.State(bottomSheetType: .me)
+                    state.bottomSheet = BottomSheetStore.State(feedId: id, bottomSheetType: .me)
                 default:
                     break
                 }

--- a/PIMO/Sources/View/Archive/ArchiveView.swift
+++ b/PIMO/Sources/View/Archive/ArchiveView.swift
@@ -54,6 +54,15 @@ struct ArchiveView: View {
                 .toast(isShowing: viewStore.binding(\.$isShowToast),
                        title: viewStore.toastMessage.title,
                        message: viewStore.toastMessage.message)
+                .sheet(isPresented: viewStore.binding(\.$isBottomSheetPresented)) {
+                    IfLetStore(
+                        self.store.scope(state: \.bottomSheet, action: { .bottomSheet($0) })
+                    ) {
+                        BottomSheetView(store: $0)
+                            .presentationDragIndicator(.visible)
+                            .presentationDetents([.height((viewStore.bottomSheet?.bottomSheetType == .me) ? 110 : 60)])
+                    }
+                }
             }
         }
     }

--- a/PIMO/Sources/View/BottomSheet/BottomSheetStore.swift
+++ b/PIMO/Sources/View/BottomSheet/BottomSheetStore.swift
@@ -12,13 +12,14 @@ import ComposableArchitecture
 
 struct BottomSheetStore: ReducerProtocol {
     struct State: Equatable {
+        var feedId: Int = 0
         var bottomSheetType: BottomSheetType = .me
     }
     
     enum Action: Equatable {
-        case editButtonDidTap
-        case deleteButtonDidTap
-        case declationButtonDidTap
+        case editButtonDidTap(Int)
+        case deleteButtonDidTap(Int)
+        case declationButtonDidTap(Int)
     }
     
     var body: some ReducerProtocol<State, Action> {

--- a/PIMO/Sources/View/BottomSheet/BottomSheetStore.swift
+++ b/PIMO/Sources/View/BottomSheet/BottomSheetStore.swift
@@ -1,0 +1,32 @@
+//
+//  BottomSheetStore.swift
+//  PIMO
+//
+//  Created by 김영인 on 2023/03/21.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+struct BottomSheetStore: ReducerProtocol {
+    struct State: Equatable {
+        var bottomSheetType: BottomSheetType = .me
+    }
+    
+    enum Action: Equatable {
+        case editButtonDidTap
+        case deleteButtonDidTap
+        case declationButtonDidTap
+    }
+    
+    var body: some ReducerProtocol<State, Action> {
+        Reduce { _, action in
+            switch action {
+            default:
+                return .none
+            }
+        }
+    }
+}

--- a/PIMO/Sources/View/BottomSheet/BottomSheetView.swift
+++ b/PIMO/Sources/View/BottomSheet/BottomSheetView.swift
@@ -22,7 +22,7 @@ struct BottomSheetView: View {
                 if viewStore.bottomSheetType == .me {
                     bottomSheetText(text: "수정하기")
                         .onTapGesture {
-                            viewStore.send(.editButtonDidTap)
+                            viewStore.send(.editButtonDidTap(viewStore.feedId))
                         }
                     
                     Spacer()
@@ -30,12 +30,12 @@ struct BottomSheetView: View {
                     
                     bottomSheetText(text: "삭제하기")
                         .onTapGesture {
-                            viewStore.send(.deleteButtonDidTap)
+                            viewStore.send(.deleteButtonDidTap((viewStore.feedId)))
                         }
                 } else {
                     bottomSheetText(text: "신고하기")
                         .onTapGesture {
-                            viewStore.send(.declationButtonDidTap)
+                            viewStore.send(.declationButtonDidTap((viewStore.feedId)))
                         }
                 }
             }

--- a/PIMO/Sources/View/BottomSheet/BottomSheetView.swift
+++ b/PIMO/Sources/View/BottomSheet/BottomSheetView.swift
@@ -1,0 +1,49 @@
+//
+//  BottomSheetView.swift
+//  PIMO
+//
+//  Created by 김영인 on 2023/03/21.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+struct BottomSheetView: View {
+    let store: StoreOf<BottomSheetStore>
+    
+    var body: some View {
+        WithViewStore(self.store, observe: { $0 }) { viewStore in
+            VStack(alignment: .center) {
+                Spacer()
+                    .frame(height: 32)
+                
+                if viewStore.bottomSheetType == .me {
+                    bottomSheetText(text: "수정하기")
+                        .onTapGesture {
+                            viewStore.send(.editButtonDidTap)
+                        }
+                    
+                    Spacer()
+                        .frame(height: 26)
+                    
+                    bottomSheetText(text: "삭제하기")
+                        .onTapGesture {
+                            viewStore.send(.deleteButtonDidTap)
+                        }
+                } else {
+                    bottomSheetText(text: "신고하기")
+                        .onTapGesture {
+                            viewStore.send(.declationButtonDidTap)
+                        }
+                }
+            }
+        }
+    }
+    
+    func bottomSheetText(text: String) -> some View {
+        Text(text)
+            .font(Font(PIMOFontFamily.Pretendard.regular.font(size: 18)))
+    }
+}

--- a/PIMO/Sources/View/Components/PopupView.swift
+++ b/PIMO/Sources/View/Components/PopupView.swift
@@ -23,7 +23,7 @@ struct PopupView: View {
 
     var body: some View {
         ZStack {
-            Color.black.opacity(0.5).ignoresSafeArea()
+            Color.black.opacity(0.1).ignoresSafeArea()
             ZStack {
                 Color.white
                 VStack(alignment: .leading, spacing: 0) {

--- a/PIMO/Sources/View/Feed/FeedStore.swift
+++ b/PIMO/Sources/View/Feed/FeedStore.swift
@@ -50,8 +50,6 @@ struct FeedStore: ReducerProtocol {
                     return .none
                 }
                 state.closeButtonDidTap = isClosed
-            case .moreButtonDidTap:
-                #warning("바텀시트")
             case .closeButtonDidTap:
                 UserUtill.shared.setUserDefaults(key: .closedTextGuide, value: true)
                 state.closeButtonDidTap = true

--- a/PIMO/Sources/View/Home/HomeStore.swift
+++ b/PIMO/Sources/View/Home/HomeStore.swift
@@ -19,7 +19,7 @@ struct HomeStore: ReducerProtocol {
     struct State: Equatable {
         @BindingState var path: [HomeScene] = []
         @BindingState var isShowToast: Bool = false
-        @BindingState var isBottomSheetPresented = false
+        @BindingState var isBottomSheetPresented: Bool = false
         var toastMessage: ToastModel = ToastModel(title: PIMOStrings.textCopyToastTitle,
                                                   message: PIMOStrings.textCopyToastMessage)
         var feeds: IdentifiedArrayOf<FeedStore.State> = []
@@ -86,7 +86,7 @@ struct HomeStore: ReducerProtocol {
                     state.isShowToast = true
                 case let .moreButtonDidTap(id):
                     state.isBottomSheetPresented = true
-                    state.bottomSheet = BottomSheetStore.State(bottomSheetType: .me)
+                    state.bottomSheet = BottomSheetStore.State(feedId: id, bottomSheetType: .me)
                 case .audioButtonDidTap:
                     guard let feedId = state.audioPlayingFeedId else {
                         state.audioPlayingFeedId = id

--- a/PIMO/Sources/View/Home/HomeStore.swift
+++ b/PIMO/Sources/View/Home/HomeStore.swift
@@ -19,10 +19,12 @@ struct HomeStore: ReducerProtocol {
     struct State: Equatable {
         @BindingState var path: [HomeScene] = []
         @BindingState var isShowToast: Bool = false
+        @BindingState var isBottomSheetPresented = false
         var toastMessage: ToastModel = ToastModel(title: PIMOStrings.textCopyToastTitle,
                                                   message: PIMOStrings.textCopyToastMessage)
         var feeds: IdentifiedArrayOf<FeedStore.State> = []
         var setting: SettingStore.State?
+        var bottomSheet: BottomSheetStore.State?
         var audioPlayingFeedId: Int?
     }
     
@@ -36,6 +38,7 @@ struct HomeStore: ReducerProtocol {
         case receiveProfileInfo(Profile)
         case setting(SettingStore.Action)
         case onboarding(OnboardingStore.Action)
+        case bottomSheet(BottomSheetStore.Action)
     }
     
     @Dependency(\.homeClient) var homeClient
@@ -81,6 +84,9 @@ struct HomeStore: ReducerProtocol {
                 case let .copyButtonDidTap(text):
                     pasteboard.string = text
                     state.isShowToast = true
+                case let .moreButtonDidTap(id):
+                    state.isBottomSheetPresented = true
+                    state.bottomSheet = BottomSheetStore.State(bottomSheetType: .me)
                 case .audioButtonDidTap:
                     guard let feedId = state.audioPlayingFeedId else {
                         state.audioPlayingFeedId = id
@@ -92,6 +98,15 @@ struct HomeStore: ReducerProtocol {
                     state.audioPlayingFeedId = id
                 default:
                     break
+                }
+            case let .bottomSheet(action):
+                switch action {
+                case .editButtonDidTap:
+                    state.isBottomSheetPresented = false
+                case .deleteButtonDidTap:
+                    state.isBottomSheetPresented = false
+                case .declationButtonDidTap:
+                    state.isBottomSheetPresented = false
                 }
             case .receiveProfileInfo(let profile):
                 #warning("API연결")
@@ -106,6 +121,9 @@ struct HomeStore: ReducerProtocol {
         }
         .ifLet(\.setting, action: /Action.setting) {
             SettingStore()
+        }
+        .ifLet(\.bottomSheet, action: /Action.bottomSheet) {
+            BottomSheetStore()
         }
         .forEach(\.feeds, action: /Action.feed(id:action:)) {
             FeedStore()

--- a/PIMO/Sources/View/Home/HomeView.swift
+++ b/PIMO/Sources/View/Home/HomeView.swift
@@ -45,6 +45,15 @@ struct HomeView: View {
             .toast(isShowing: viewStore.binding(\.$isShowToast),
                    title: viewStore.toastMessage.title,
                    message: viewStore.toastMessage.message)
+            .sheet(isPresented: viewStore.binding(\.$isBottomSheetPresented)) {
+                IfLetStore(
+                    self.store.scope(state: \.bottomSheet, action: { .bottomSheet($0) })
+                ) {
+                    BottomSheetView(store: $0)
+                        .presentationDragIndicator(.visible)
+                        .presentationDetents([.height((viewStore.bottomSheet?.bottomSheetType == .me) ? 110 : 60)])
+                }
+            }
         }
     }
     

--- a/PIMO/Sources/View/Modifier/ClosePopup.swift
+++ b/PIMO/Sources/View/Modifier/ClosePopup.swift
@@ -11,9 +11,9 @@ import SwiftUI
 import ComposableArchitecture
 
 extension View {
-    func closePopup(isShowing: Binding<Bool>) -> some View {
-        return self.modifier(RemovePopupViewModifier(isShowing: isShowing))
-    }
+//    func closePopup(isShowing: Binding<Bool>) -> some View {
+//        return self.modifier(RemovePopupViewModifier(isShowing: isShowing))
+//    }
 }
 
 struct ClosePopupViewModifier: ViewModifier {

--- a/PIMO/Sources/View/Modifier/RemovePopup.swift
+++ b/PIMO/Sources/View/Modifier/RemovePopup.swift
@@ -8,15 +8,17 @@
 
 import SwiftUI
 
+import ComposableArchitecture
+
 extension View {
-    func removePopup(isShowing: Binding<Bool>) -> some View {
-        return self.modifier(RemovePopupViewModifier(isShowing: isShowing))
+    func removePopup(isShowing: Binding<Bool>, store: ViewStore<TabBarStore.State, TabBarStore.Action>) -> some View {
+        return self.modifier(RemovePopupViewModifier(isShowing: isShowing, store: store))
     }
 }
 
 struct RemovePopupViewModifier: ViewModifier {
-    // TODO: Store 추가 필요
     @Binding var isShowing: Bool
+    let store: ViewStore<TabBarStore.State, TabBarStore.Action>
 
     func body(content: Content) -> some View {
         ZStack {
@@ -53,15 +55,9 @@ struct RemovePopupViewModifier: ViewModifier {
                     }, type: .cancel),
                     PopupButton(buttonText: "삭제하기", buttonCompletionHandler: {
                         isShowing = false
+                        store.send(.deleteFeed)
                     }, type: .destructive)
                 ])
         }
-    }
-}
-
-struct RemovePopupViewModifier_Previews: PreviewProvider {
-    static var previews: some View {
-        Text("Hello World!")
-            .removePopup(isShowing: .constant(true))
     }
 }

--- a/PIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/PIMO/Sources/View/TabBar/TabBarStore.swift
@@ -15,12 +15,13 @@ struct TabBarStore: ReducerProtocol {
         @BindingState var tabBarItem: TabBarItem = .home
         @BindingState var isSheetPresented: Bool = false
         @BindingState var isShowToast: Bool = false
+        @BindingState var isShowRemovePopup: Bool = false
         var toastMessage: ToastModel = ToastModel(title: PIMOStrings.textCopyToastTitle,
                                                   message: PIMOStrings.textCopyToastMessage)
         var myProfile: Profile?
         var homeState = HomeStore.State()
         var uploadState = UploadStore.State()
-        var myFeedState = ArchiveStore.State()
+        var archiveState = ArchiveStore.State()
     }
     
     enum Action: BindableAction, Equatable {
@@ -32,7 +33,8 @@ struct TabBarStore: ReducerProtocol {
         case setSheetState
         case home(HomeStore.Action)
         case upload(UploadStore.Action)
-        case myFeed(ArchiveStore.Action)
+        case archive(ArchiveStore.Action)
+        case deleteFeed
     }
 
     struct CancelID: Hashable {
@@ -75,11 +77,16 @@ struct TabBarStore: ReducerProtocol {
                 state.isSheetPresented = true
             case .upload(.didTapCloseButton):
                 state.isSheetPresented = false
-
             case .home(.settingButtonDidTap):
                 return .send(.home(.receiveProfileInfo(state.myProfile ?? Profile.EMPTY)))
-            case .myFeed(.settingButtonDidTap):
-                return .send(.myFeed(.receiveProfileInfo(state.myProfile ?? Profile.EMPTY)))
+            case .home(.bottomSheet(.deleteButtonDidTap(let feedId))):
+                state.isShowRemovePopup = true
+                let _ = print(feedId)
+            case .archive(.settingButtonDidTap):
+                return .send(.archive(.receiveProfileInfo(state.myProfile ?? Profile.EMPTY)))
+            case .archive(.bottomSheet(.deleteButtonDidTap(let feedId))):
+                state.isShowRemovePopup = true
+                let _ = print(feedId)
             default:
                 return .none
             }
@@ -95,7 +102,7 @@ struct TabBarStore: ReducerProtocol {
             UploadStore()
         }
         
-        Scope(state: \.myFeedState, action: /Action.myFeed) {
+        Scope(state: \.archiveState, action: /Action.archive) {
             ArchiveStore()
         }
     }

--- a/PIMO/Sources/View/TabBar/TabBarView.swift
+++ b/PIMO/Sources/View/TabBar/TabBarView.swift
@@ -29,8 +29,8 @@ struct TabBarView: View {
                     
                     ArchiveView(
                         store: store.scope(
-                            state: \.myFeedState,
-                            action: TabBarStore.Action.myFeed
+                            state: \.archiveState,
+                            action: TabBarStore.Action.archive
                         )
                     )
                     .tag(tabBarItems[1])
@@ -47,6 +47,7 @@ struct TabBarView: View {
             }
             .ignoresSafeArea(.all)
             .toast(isShowing: viewStore.binding(\.$isShowToast), title: viewStore.toastMessage.title)
+            .removePopup(isShowing: viewStore.binding(\.$isShowRemovePopup), store: viewStore)
         }
     }
     


### PR DESCRIPTION
close: #37

### What is this PR?
[Feature/#37] 피드 바텀시트 구현

### Changes
피드 바텀시트 구현했습니다.

### 피드 바텀시트 종류
- 나의 게시글일 경우 [수정하기, 삭제하기]
- 타인의 게시글일 경우 [신고하기]

|나|타인 게시물|
|:--:|:--:|
|<img src ="https://user-images.githubusercontent.com/74968390/226522299-61335c7a-56ea-40b0-a6b2-7aa2be0280aa.png" width= "250">|<img src ="https://user-images.githubusercontent.com/74968390/226522305-ec86355a-ef66-4fe3-aa84-66c43aacdfad.png" width ="250">|

### 게시물 삭제 팝업창
TabBar 영역까지 전부 dim처리 및 선택되지 않아야 하기 때문에
TabBarStore에서 해당 팝업 처리했습니다.

<img src ="https://user-images.githubusercontent.com/74968390/226522764-60e5584f-4262-4381-99ae-994d6bae9a16.png" width ="250">

### 논의사항
1. 현재 상황이라면 게시물 삭제 네트워크를 TabBarStore에서 처리하게 될 것 같은데 혹시 다른 더 좋은 방식이 있다면 말해주세요 . .
2. 신고하기 버튼을 누르면 토스트로 신고가 완료되었습니다 띄우는 방식을 생각중인데 어떻게 생각하시나요 ?
3. 바텀시트는 기본으로 제공하는 걸로 써서 배경 dim이 매우 연해 팝업창 배경 opacity를 0.1로 바꿔 비슷하게 보이도록 했습니다.(개발 리소스를 덜기 위해..) 괜찮을까요 ? ?
<img src = "https://user-images.githubusercontent.com/74968390/226522710-08d08d5c-b934-4cbd-b150-2966e04cfde1.gif" width = "250">