### PR TITLE
[feature/ #21] 프로필 기입, 수정 관련 네트워크 연결 등

### DIFF
--- a/PIMO/Sources/Network/Client/ProfileClient.swift
+++ b/PIMO/Sources/Network/Client/ProfileClient.swift
@@ -43,17 +43,17 @@ extension ProfileClient: DependencyKey {
     } deleteProfile: {
         let request = ProfileCheckRequest(target: .deleteProfile)
 
-        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+        return BaseNetwork.shared.requestWithNoResponse(api: request, isInterceptive: true)
             .catchToEffect()
     } fetchIsExistsNickname: { nickname in
         let request = ProfileCheckRequest(target: .fetchIsExistsNickname(nickname))
 
-        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+        return BaseNetwork.shared.requestWithNoResponse(api: request, isInterceptive: true)
             .catchToEffect()
     } fetchIsExistsArchiveName: { archiveName in
         let request = ProfileCheckRequest(target: .fetchIsExistsArchiveName(archiveName))
 
-        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+        return BaseNetwork.shared.requestWithNoResponse(api: request, isInterceptive: true)
             .catchToEffect()
     } patchNickname: { nickname in
         let request = ProfileRequest(target: .patchNickname(nickname: nickname))

--- a/PIMO/Sources/Network/Client/ProfileClient.swift
+++ b/PIMO/Sources/Network/Client/ProfileClient.swift
@@ -13,6 +13,13 @@ import ComposableArchitecture
 
 struct ProfileClient {
     let fetchMyProfile: () -> EffectTask<Result<Profile, NetworkError>>
+    let saveProfile: ((nickname: String, archiveName: String, profileImgURL: String)) -> EffectTask<Result<Profile, NetworkError>>
+    let deleteProfile: () -> EffectTask<Result<Bool, NetworkError>>
+    let fetchIsExistsNickname: (String) -> EffectTask<Result<Bool, NetworkError>>
+    let fetchIsExistsArchiveName: (String) -> EffectTask<Result<Bool, NetworkError>>
+    let patchNickname: (String) -> EffectTask<Result<Profile, NetworkError>>
+    let patchArchiveName: (String) -> EffectTask<Result<Profile, NetworkError>>
+    let patchProfileImage: (String) -> EffectTask<Result<Profile, NetworkError>>
 }
 
 extension DependencyValues {
@@ -26,7 +33,43 @@ extension ProfileClient: DependencyKey {
     static let liveValue = Self.init {
         let request = ProfileRequest(target: .fetchMyProfile)
 
-        return BaseNetwork.shared.request(api: request, isInterceptive: false)
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+            .catchToEffect()
+    } saveProfile: { (nickname, archiveName, profileImageURL) in
+        let request = ProfileRequest(target: .saveProfile(nickname: nickname, archiveName: archiveName, profileImgURL: profileImageURL))
+
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+            .catchToEffect()
+    } deleteProfile: {
+        let request = ProfileCheckRequest(target: .deleteProfile)
+
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+            .catchToEffect()
+    } fetchIsExistsNickname: { nickname in
+        let request = ProfileCheckRequest(target: .fetchIsExistsNickname(nickname))
+
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+            .catchToEffect()
+    } fetchIsExistsArchiveName: { archiveName in
+        let request = ProfileCheckRequest(target: .fetchIsExistsArchiveName(archiveName))
+
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+            .catchToEffect()
+    } patchNickname: { nickname in
+        let request = ProfileRequest(target: .patchNickname(nickname: nickname))
+
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+            .catchToEffect()
+    } patchArchiveName: { archiveName in
+        let request = ProfileRequest(target: .patchArchiveName(archiveName: archiveName))
+
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+            .catchToEffect()
+    } patchProfileImage: { profileImageURL in
+        let request = ProfileRequest(target: .patchprofileImage(profilImageURL: profileImageURL))
+
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
             .catchToEffect()
     }
+
 }

--- a/PIMO/Sources/Network/RequestModel/ProfileCheckRequest.swift
+++ b/PIMO/Sources/Network/RequestModel/ProfileCheckRequest.swift
@@ -1,0 +1,65 @@
+//
+//  ProfileCheckRequest.swift
+//  PIMO
+//
+//  Created by Ok Hyeon Kim on 2023/03/27.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+enum ProfileCheckTarget {
+    case deleteProfile
+    case fetchIsExistsNickname(String)
+#warning("API 미확정")
+    case fetchIsExistsArchiveName(String)
+}
+
+struct ProfileCheckRequest: Requestable {
+    typealias Response = Bool
+    let target: ProfileCheckTarget
+
+    var path: String {
+        switch target {
+        case .deleteProfile:
+            return "/users"
+        case .fetchIsExistsNickname:
+            return "users/exists/nickname"
+        case .fetchIsExistsArchiveName:
+            return "users/exists/archiveName"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch target {
+        case .fetchIsExistsNickname, .fetchIsExistsArchiveName:
+            return .get
+        case .deleteProfile:
+            return .delete
+        }
+    }
+
+    var parameters: Parameters {
+        switch target {
+        case .deleteProfile:
+            return [:]
+        case let .fetchIsExistsNickname(nickname):
+            return [
+                "nickname": nickname
+            ]
+        case let .fetchIsExistsArchiveName(archiveName):
+            return [
+                "archiveName": archiveName
+            ]
+        }
+    }
+
+    var header: [HTTPFields: String] {
+        return [
+            HTTPFields.authorization: HTTPHeaderType.authorization.header
+        ]
+    }
+}
+

--- a/PIMO/Sources/Network/RequestModel/ProfileRequest.swift
+++ b/PIMO/Sources/Network/RequestModel/ProfileRequest.swift
@@ -13,6 +13,14 @@ import Alamofire
 enum ProfileTarget {
     case fetchMyProfile
     case fetchOtherProfile(String)
+
+#warning("API 미확정")
+    case saveProfile(nickname: String, archiveName: String, profileImgURL: String)
+    case patchNickname(nickname: String)
+
+#warning("API 미확정")
+    case patchArchiveName(archiveName: String)
+    case patchprofileImage(profilImageURL: String)
 }
 
 struct ProfileRequest: Requestable {
@@ -21,15 +29,28 @@ struct ProfileRequest: Requestable {
     
     var path: String {
         switch target {
-        case .fetchMyProfile:
+        case .fetchMyProfile, .saveProfile:
             return "/users"
         case .fetchOtherProfile:
             return "/users/search"
+        case .patchNickname:
+            return "users/nickname"
+        case .patchArchiveName:
+            return "users/archiveName"
+        case .patchprofileImage:
+            return "users/profile"
         }
     }
     
     var method: HTTPMethod {
-        return .get
+        switch target {
+        case .fetchMyProfile, .fetchOtherProfile:
+            return .get
+        case .saveProfile:
+            return .post
+        case .patchprofileImage, .patchNickname, .patchArchiveName:
+            return .patch
+        }
     }
     
     var parameters: Parameters {
@@ -38,6 +59,24 @@ struct ProfileRequest: Requestable {
             return [:]
         case let .fetchOtherProfile(userId):
             return ["userId": userId]
+        case let .saveProfile(nickname, archiveName, profileImgURL):
+            return [
+                "nickName": nickname,
+                "archiveName": archiveName,
+                "profileImgUrl": profileImgURL
+            ]
+        case let .patchNickname(nickname):
+            return [
+                "nickname": nickname
+            ]
+        case let .patchArchiveName(archiveName):
+            return [
+                "archiveName": archiveName
+            ]
+        case let .patchprofileImage(profilImageURL):
+            return [
+                "profile": profilImageURL
+            ]
         }
     }
     

--- a/PIMO/Sources/View/Archive/ArchiveStore.swift
+++ b/PIMO/Sources/View/Archive/ArchiveStore.swift
@@ -32,6 +32,7 @@ enum ArchiveScene: Hashable {
     case friends
     case setting
     case openSourceLicence
+    case modifyProfile
 }
 
 struct ArchiveStore: ReducerProtocol {
@@ -52,6 +53,7 @@ struct ArchiveStore: ReducerProtocol {
         var friends: FriendsListStore.State?
         var setting: SettingStore.State?
         var bottomSheet: BottomSheetStore.State?
+        var profile: ProfileSettingStore.State?
         var audioPlayingFeedId: Int?
     }
     
@@ -71,6 +73,7 @@ struct ArchiveStore: ReducerProtocol {
         case friends(FriendsListStore.Action)
         case setting(SettingStore.Action)
         case bottomSheet(BottomSheetStore.Action)
+        case profile(ProfileSettingStore.Action)
     }
     
     @Dependency(\.archiveClient) var archiveClient
@@ -188,6 +191,18 @@ struct ArchiveStore: ReducerProtocol {
                     clapCount: feed.clapCount,
                     isClapped: feed.isClapped
                 )
+            case .setting(.tappedProfileManagementButton):
+#warning("API연결")
+                state.profile = ProfileSettingStore.State(
+                    nickname: state.setting?.nickname ?? "",
+                    archiveName: "",
+                    selectedImageURL: state.setting?.imageURLString ?? ""
+                )
+                state.path.append(.modifyProfile)
+            case .profile(.acceptBack):
+                if state.path.last == .modifyProfile {
+                    state.path.removeLast()
+                }
             default:
                 break
             }
@@ -204,6 +219,9 @@ struct ArchiveStore: ReducerProtocol {
         }
         .ifLet(\.bottomSheet, action: /Action.bottomSheet) {
             BottomSheetStore()
+        }
+        .ifLet(\.profile, action: /Action.profile) {
+            ProfileSettingStore()
         }
         .forEach(\.feeds, action: /Action.feed(id:action:)) {
             FeedStore()

--- a/PIMO/Sources/View/Archive/ArchiveStore.swift
+++ b/PIMO/Sources/View/Archive/ArchiveStore.swift
@@ -199,10 +199,6 @@ struct ArchiveStore: ReducerProtocol {
                     selectedImageURL: state.setting?.imageURLString ?? ""
                 )
                 state.path.append(.modifyProfile)
-            case .profile(.acceptBack):
-                if state.path.last == .modifyProfile {
-                    state.path.removeLast()
-                }
             default:
                 break
             }

--- a/PIMO/Sources/View/Archive/ArchiveView.swift
+++ b/PIMO/Sources/View/Archive/ArchiveView.swift
@@ -50,6 +50,12 @@ struct ArchiveView: View {
 
                     case .openSourceLicence:
                         AcknowView()
+                    case .modifyProfile:
+                        IfLetStore(
+                            self.store.scope(state: \.profile, action: { .profile($0) })
+                        ) {
+                            ModifyProfileView(store: $0)
+                        }
                     default:
                         EmptyView()
                     }

--- a/PIMO/Sources/View/Base/CustomNavigationBar.swift
+++ b/PIMO/Sources/View/Base/CustomNavigationBar.swift
@@ -14,6 +14,7 @@ struct CustomNavigationBar: View {
     let title: String
     var trailingItemType: TrailingItemType = .none
     var isShadowed: Bool = false
+    var backButtonAction: (() -> Void)?
     var screenWidth: CGFloat {
         sceneDelegate.window?.bounds.width ?? 0
     }
@@ -28,7 +29,12 @@ struct CustomNavigationBar: View {
 
             HStack {
                 Button {
-                    presentation.wrappedValue.dismiss()
+                    if backButtonAction == nil {
+                        presentation.wrappedValue.dismiss()
+                    } else {
+                        backButtonAction?()
+                    }
+
                 } label: {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18))

--- a/PIMO/Sources/View/Home/HomeStore.swift
+++ b/PIMO/Sources/View/Home/HomeStore.swift
@@ -137,6 +137,10 @@ struct HomeStore: ReducerProtocol {
                     selectedImageURL: state.setting?.imageURLString ?? ""
                 )
                 state.path.append(.modifyProfile)
+            case .profile(.acceptBack):
+                if state.path.last == .modifyProfile {
+                    state.path.removeLast()
+                }
             default:
                 break
             }

--- a/PIMO/Sources/View/Home/HomeStore.swift
+++ b/PIMO/Sources/View/Home/HomeStore.swift
@@ -137,10 +137,6 @@ struct HomeStore: ReducerProtocol {
                     selectedImageURL: state.setting?.imageURLString ?? ""
                 )
                 state.path.append(.modifyProfile)
-            case .profile(.acceptBack):
-                if state.path.last == .modifyProfile {
-                    state.path.removeLast()
-                }
             default:
                 break
             }

--- a/PIMO/Sources/View/Home/HomeStore.swift
+++ b/PIMO/Sources/View/Home/HomeStore.swift
@@ -14,6 +14,7 @@ enum HomeScene: Hashable {
     case home
     case setting
     case openSourceLicence
+    case modifyProfile
 }
 
 struct HomeStore: ReducerProtocol {
@@ -26,6 +27,7 @@ struct HomeStore: ReducerProtocol {
         var feeds: IdentifiedArrayOf<FeedStore.State> = []
         var setting: SettingStore.State?
         var bottomSheet: BottomSheetStore.State?
+        var profile: ProfileSettingStore.State?
         var audioPlayingFeedId: Int?
     }
     
@@ -41,6 +43,7 @@ struct HomeStore: ReducerProtocol {
         case setting(SettingStore.Action)
         case onboarding(OnboardingStore.Action)
         case bottomSheet(BottomSheetStore.Action)
+        case profile(ProfileSettingStore.Action)
     }
     
     @Dependency(\.homeClient) var homeClient
@@ -119,13 +122,21 @@ struct HomeStore: ReducerProtocol {
                     state.isBottomSheetPresented = false
                 }
             case .receiveProfileInfo(let profile):
-                #warning("API연결")
+#warning("API연결")
                 state.setting = SettingStore.State(nickname: profile.nickName,
                                                    archiveName: "",
                                                    imageURLString: profile.profileImgUrl)
                 state.path.append(.setting)
             case .setting(.tappedLicenceButton):
                 state.path.append(.openSourceLicence)
+            case .setting(.tappedProfileManagementButton):
+#warning("API연결")
+                state.profile = ProfileSettingStore.State(
+                    nickname: state.setting?.nickname ?? "",
+                    archiveName: "",
+                    selectedImageURL: state.setting?.imageURLString ?? ""
+                )
+                state.path.append(.modifyProfile)
             default:
                 break
             }

--- a/PIMO/Sources/View/Home/HomeStore.swift
+++ b/PIMO/Sources/View/Home/HomeStore.swift
@@ -151,5 +151,8 @@ struct HomeStore: ReducerProtocol {
         .forEach(\.feeds, action: /Action.feed(id:action:)) {
             FeedStore()
         }
+        .ifLet(\.profile, action: /Action.profile) {
+            ProfileSettingStore()
+        }
     }
 }

--- a/PIMO/Sources/View/Home/HomeView.swift
+++ b/PIMO/Sources/View/Home/HomeView.swift
@@ -39,6 +39,12 @@ struct HomeView: View {
                         }
                     case .openSourceLicence:
                         AcknowView()
+                    case .modifyProfile:
+                        IfLetStore(
+                            self.store.scope(state: \.profile, action: { .profile($0) })
+                        ) {
+                            ModifyProfileView(store: $0)
+                        }
                     default:
                         EmptyView()
                     }

--- a/PIMO/Sources/View/Modifier/ModifyProfileBackPopup.swift
+++ b/PIMO/Sources/View/Modifier/ModifyProfileBackPopup.swift
@@ -11,14 +11,14 @@ import SwiftUI
 import ComposableArchitecture
 
 extension View {
-    func modifyProfileBackPopup(isShowing: Binding<Bool>, store: ViewStore<ProfileSettingStore.State, ProfileSettingStore.Action>) -> some View {
+    func modifyProfileBackPopup(isShowing: Binding<Bool>, store: ViewStore<TabBarStore.State, TabBarStore.Action>) -> some View {
         return self.modifier(ModifyProfileBackPopupViewModifier(isShowing: isShowing, store: store))
     }
 }
 
 struct ModifyProfileBackPopupViewModifier: ViewModifier {
     @Binding var isShowing: Bool
-    let store: ViewStore<ProfileSettingStore.State, ProfileSettingStore.Action>
+    let store: ViewStore<TabBarStore.State, TabBarStore.Action>
 
     func body(content: Content) -> some View {
         ZStack {
@@ -54,7 +54,7 @@ struct ModifyProfileBackPopupViewModifier: ViewModifier {
                         isShowing = false
                     }, type: .cancel),
                     PopupButton(buttonText: "나가기", buttonCompletionHandler: {
-                        store.send(.acceptBack)
+                        store.send(.acceptBackOnProfileSetting)
                         isShowing = false
                     }, type: .destructive)
                 ])

--- a/PIMO/Sources/View/Modifier/ModifyProfileBackPopup.swift
+++ b/PIMO/Sources/View/Modifier/ModifyProfileBackPopup.swift
@@ -1,0 +1,63 @@
+//
+//  ModifyProfileBackPopup.swift
+//  PIMO
+//
+//  Created by Ok Hyeon Kim on 2023/03/29.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+extension View {
+    func modifyProfileBackPopup(isShowing: Binding<Bool>, store: ViewStore<ProfileSettingStore.State, ProfileSettingStore.Action>) -> some View {
+        return self.modifier(ModifyProfileBackPopupViewModifier(isShowing: isShowing, store: store))
+    }
+}
+
+struct ModifyProfileBackPopupViewModifier: ViewModifier {
+    @Binding var isShowing: Bool
+    let store: ViewStore<ProfileSettingStore.State, ProfileSettingStore.Action>
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+
+            if isShowing {
+                Rectangle()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .foregroundColor(.black)
+                    .opacity(0.5)
+                    .onTapGesture {
+                        withAnimation {
+                            isShowing = false
+                        }
+                    }
+                    .ignoresSafeArea()
+
+                popup
+                    .zIndex(1)
+                    .animation(.easeInOut(duration: 0.2), value: isShowing)
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    private var popup: some View {
+        ZStack(alignment: .center) {
+            PopupView(
+                title: "수정한 내용이 저장되지 않습니다",
+                message: "정말 나가시겠습니까?",
+                popupButtons: [
+                    PopupButton(buttonText: "취소하기", buttonCompletionHandler: {
+                        isShowing = false
+                    }, type: .cancel),
+                    PopupButton(buttonText: "나가기", buttonCompletionHandler: {
+                        store.send(.acceptBack)
+                        isShowing = false
+                    }, type: .destructive)
+                ])
+        }
+    }
+}

--- a/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
+++ b/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
@@ -17,6 +17,10 @@ struct ModifyProfileView: View {
     var body: some View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             VStack(alignment: .leading, spacing: 0) {
+                CustomNavigationBar(title: "프로필 수정") {
+                    viewStore.send(.tappedBackButton)
+                }
+
                 VStack(alignment: .leading, spacing: 0) {
 
                     profileImageButton(viewStore)
@@ -57,7 +61,10 @@ struct ModifyProfileView: View {
             .onAppear {
                 viewStore.send(.onAppear)
             }
+            .toolbar(.hidden, for: .navigationBar)
+            .modifyProfileBackPopup(isShowing: viewStore.binding(\.$isShowExitPopup), store: viewStore)
         }
+
     }
 
     func profileImageButton(_ viewStore: ViewStore<ProfileSettingStore.State, ProfileSettingStore.Action>) -> some View {

--- a/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
+++ b/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 import ComposableArchitecture
+import Kingfisher
 
 struct ModifyProfileView: View {
     let store: StoreOf<ProfileSettingStore>
@@ -58,7 +59,7 @@ struct ModifyProfileView: View {
 
     func profileImageButton(_ viewStore: ViewStore<ProfileSettingStore.State, ProfileSettingStore.Action>) -> some View {
         ZStack(alignment: .bottomTrailing) {
-            Image(uiImage: viewStore.selectedProfileImage ?? UIImage())
+            KFImage(URL(string: viewStore.selectedImageURL ?? ""))
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 120, height: 120)

--- a/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
+++ b/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
@@ -62,7 +62,6 @@ struct ModifyProfileView: View {
                 viewStore.send(.onAppear)
             }
             .toolbar(.hidden, for: .navigationBar)
-            .modifyProfileBackPopup(isShowing: viewStore.binding(\.$isShowExitPopup), store: viewStore)
         }
 
     }

--- a/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
+++ b/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
@@ -54,6 +54,9 @@ struct ModifyProfileView: View {
                     viewStore.send(.selectProfileImage(uiImage))
                 }
             }
+            .onAppear {
+                viewStore.send(.onAppear)
+            }
         }
     }
 
@@ -64,6 +67,7 @@ struct ModifyProfileView: View {
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 120, height: 120)
                 .cornerRadius(4)
+                .zIndex(0)
 
             ZStack {
                 Rectangle()
@@ -75,6 +79,7 @@ struct ModifyProfileView: View {
             .compositingGroup()
             .foregroundColor(.black)
             .opacity(0.6)
+            .zIndex(1)
 
             Button {
                 viewStore.send(.tappedImagePickerButton)
@@ -88,6 +93,7 @@ struct ModifyProfileView: View {
                 }
             }
             .offset(.init(width: 7, height: 12))
+            .zIndex(2)
         }
         .frame(maxWidth: .infinity)
         .padding(.top, 55)
@@ -97,18 +103,18 @@ struct ModifyProfileView: View {
         Button {
             viewStore.send(.tappedCompleteModifyButton)
         } label: {
-            Text("다음")
+            Text("저장하기")
                 .font(.system(size: 16))
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity, minHeight: 56)
                 .background(
-                    viewStore.isActiveButtonOnNickname && viewStore.isActiveButtonOnArchive
+                    viewStore.isChangedInfo
                     ? Color(PIMOAsset.Assets.red2.color)
                     : Color(PIMOAsset.Assets.gray1.color)
                     )
                 .cornerRadius(2)
         }
-        .disabled(!viewStore.isActiveButtonOnNickname && !viewStore.isActiveButtonOnArchive)
+        .disabled(!viewStore.isChangedInfo)
         .padding(.top, 34)
         .padding(.bottom, 60)
     }

--- a/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
+++ b/PIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
@@ -70,6 +70,10 @@ struct ModifyProfileView: View {
     func profileImageButton(_ viewStore: ViewStore<ProfileSettingStore.State, ProfileSettingStore.Action>) -> some View {
         ZStack(alignment: .bottomTrailing) {
             KFImage(URL(string: viewStore.selectedImageURL ?? ""))
+                .placeholder {
+                    Image(systemName: "person")
+                        .font(.system(size: 24))
+                }
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 120, height: 120)

--- a/PIMO/Sources/View/ProfileSetting/ProfilePictureSettingView.swift
+++ b/PIMO/Sources/View/ProfileSetting/ProfilePictureSettingView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 import ComposableArchitecture
+import Kingfisher
 
 struct ProfilePictureSettingView: View {
     let store: StoreOf<ProfileSettingStore>
@@ -57,7 +58,7 @@ struct ProfilePictureSettingView: View {
             Button(action: {
                 viewStore.send(.tappedImagePickerButton)
             }, label: {
-                if viewStore.selectedProfileImage == nil {
+                if viewStore.selectedImageURL == nil {
                     ZStack(alignment: .center) {
                         RoundedRectangle(cornerRadius: 4)
                             .stroke(Color(PIMOAsset.Assets.gray1.color), style: StrokeStyle(lineWidth: 1))
@@ -68,7 +69,7 @@ struct ProfilePictureSettingView: View {
                     }
                 } else {
                     ZStack {
-                        Image(uiImage: viewStore.selectedProfileImage ?? UIImage())
+                        KFImage(URL(string: viewStore.selectedImageURL ?? ""))
                             .resizable()
                             .aspectRatio(1.0, contentMode: .fit)
                             .cornerRadius(4)

--- a/PIMO/Sources/View/ProfileSetting/ProfileSettingStore.swift
+++ b/PIMO/Sources/View/ProfileSetting/ProfileSettingStore.swift
@@ -44,6 +44,8 @@ struct ProfileSettingStore: ReducerProtocol {
         var isActiveButtonOnImage: Bool = false
 
         var isChangedInfo: Bool = false
+
+        @BindingState var isShowExitPopup = false
     }
 
     enum Action: BindableAction, Equatable, NextButtonActionProtocol {
@@ -67,6 +69,9 @@ struct ProfileSettingStore: ReducerProtocol {
         case tappedCompleteButton
 
         case tappedCompleteModifyButton
+        case tappedBackButton
+
+        case acceptBack
     }
 
     @Dependency(\.imgurImageClient) var imgurImageClient
@@ -194,6 +199,9 @@ struct ProfileSettingStore: ReducerProtocol {
                     profileImgURL: state.selectedImageURL ?? ""
                 ))
                 .fireAndForget()
+            case .tappedBackButton:
+                state.isShowExitPopup = true
+                return .none
             default:
                 return .none
             }

--- a/PIMO/Sources/View/ProfileSetting/ProfileSettingStore.swift
+++ b/PIMO/Sources/View/ProfileSetting/ProfileSettingStore.swift
@@ -42,10 +42,13 @@ struct ProfileSettingStore: ReducerProtocol {
         var selectedProfileImage: UIImage?
         var selectedImageURL: String?
         var isActiveButtonOnImage: Bool = false
+
+        var isChangedInfo: Bool = false
     }
 
     enum Action: BindableAction, Equatable, NextButtonActionProtocol {
         case binding(BindingAction<State>)
+        case onAppear
         case sendToast(ToastModel)
         case sendToastDone
         case checkDuplicateOnNickName
@@ -73,6 +76,10 @@ struct ProfileSettingStore: ReducerProtocol {
         BindingReducer()
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                state.isBlackNicknameField = state.nickname == ""
+                state.isBlackArchiveField = state.archiveName == ""
+                return .none
             case let .sendToast(toastModel):
                 if state.isShowToast {
                     return EffectTask<Action>(value: .sendToast(toastModel))
@@ -119,6 +126,8 @@ struct ProfileSettingStore: ReducerProtocol {
                     ? .availableNickName
                     : state.nicknameValidationType
                     state.isActiveButtonOnNickname = state.nicknameValidationType == .availableNickName
+                    state.isChangedInfo = state.nicknameValidationType == .availableNickName
+
                 case .failure(let error):
                     state.toastMessage = .init(title: error.errorDescription ?? "")
                     state.isShowToast = true
@@ -166,6 +175,7 @@ struct ProfileSettingStore: ReducerProtocol {
                 case .success(let imageModel):
                     state.selectedImageURL = imageModel.link
                     state.isActiveButtonOnImage = true
+                    state.isChangedInfo = true
                     
                     return .none
                 case .failure(let error):

--- a/PIMO/Sources/View/ProfileSetting/ProfileSettingStore.swift
+++ b/PIMO/Sources/View/ProfileSetting/ProfileSettingStore.swift
@@ -104,6 +104,10 @@ struct ProfileSettingStore: ReducerProtocol {
 
                 return .none
             case .checkDuplicateOnNickName:
+                guard state.nicknameValidationType == .blank else {
+                    return .none
+                }
+
                 return profileClient.fetchIsExistsNickname(state.nickname)
                     .map {
                         Action.checkDuplicateOnNickNameDone($0)
@@ -111,8 +115,10 @@ struct ProfileSettingStore: ReducerProtocol {
             case .checkDuplicateOnNickNameDone(let result):
                 switch result {
                 case .success(let isExistsNickname):
-                    state.nicknameValidationType = isExistsNickname ? .alreadyUsedNickname : .availableNickName
-                    state.isActiveButtonOnNickname = !isExistsNickname
+                    state.nicknameValidationType = !isExistsNickname && state.nicknameValidationType == .blank
+                    ? .availableNickName
+                    : state.nicknameValidationType
+                    state.isActiveButtonOnNickname = state.nicknameValidationType == .availableNickName
                 case .failure(let error):
                     state.toastMessage = .init(title: error.errorDescription ?? "")
                     state.isShowToast = true
@@ -135,6 +141,10 @@ struct ProfileSettingStore: ReducerProtocol {
                 return .none
             case .checkDuplicateOnArchive:
 #warning("중복 확인 네트워크 연결 필요")
+                guard state.archiveValidationType == .blank else {
+                    return .none
+                }
+
                 state.isActiveButtonOnArchive = true
 
                 return .none

--- a/PIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/PIMO/Sources/View/TabBar/TabBarStore.swift
@@ -16,6 +16,7 @@ struct TabBarStore: ReducerProtocol {
         @BindingState var isSheetPresented: Bool = false
         @BindingState var isShowToast: Bool = false
         @BindingState var isShowRemovePopup: Bool = false
+        @BindingState var isShowAcceptBackPopup: Bool = false
         var toastMessage: ToastModel = ToastModel(title: PIMOStrings.textCopyToastTitle,
                                                   message: PIMOStrings.textCopyToastMessage)
         var myProfile: Profile?
@@ -35,6 +36,7 @@ struct TabBarStore: ReducerProtocol {
         case upload(UploadStore.Action)
         case archive(ArchiveStore.Action)
         case deleteFeed
+        case acceptBackOnProfileSetting
     }
 
     struct CancelID: Hashable {
@@ -87,6 +89,20 @@ struct TabBarStore: ReducerProtocol {
             case .archive(.bottomSheet(.deleteButtonDidTap(let feedId))):
                 state.isShowRemovePopup = true
                 let _ = print(feedId)
+            case .acceptBackOnProfileSetting:
+                if state.tabBarItem == .home,
+                   state.homeState.path.last == .modifyProfile {
+                    state.homeState.path.removeLast()
+                } else if state.tabBarItem == .myFeed,
+                          state.archiveState.path.last == .modifyProfile {
+                    state.archiveState.path.removeLast()
+                }
+            case .home(.profile(.tappedBackButton)):
+                state.isShowAcceptBackPopup = true
+                return .none
+            case .archive(.profile(.tappedBackButton)):
+                state.isShowAcceptBackPopup = true
+                return .none
             default:
                 return .none
             }

--- a/PIMO/Sources/View/TabBar/TabBarView.swift
+++ b/PIMO/Sources/View/TabBar/TabBarView.swift
@@ -48,6 +48,7 @@ struct TabBarView: View {
             .ignoresSafeArea(.all)
             .toast(isShowing: viewStore.binding(\.$isShowToast), title: viewStore.toastMessage.title)
             .removePopup(isShowing: viewStore.binding(\.$isShowRemovePopup), store: viewStore)
+            .modifyProfileBackPopup(isShowing: viewStore.binding(\.$isShowAcceptBackPopup), store: viewStore)
         }
     }
     

--- a/Tuist/ProjectDescriptionHelpers/InfoPlist.swift
+++ b/Tuist/ProjectDescriptionHelpers/InfoPlist.swift
@@ -10,6 +10,8 @@ extension Project {
         "LSApplicationQueriesSchemes": ["kakaokompassauth"],
         "KAKAO_NATIVE_APP_KEY": "${KAKAO_NATIVE_APP_KEY}",
         "BaseURL": "${BASE_URL}",
+        "ClientID": "${CLIENT_ID}",
+        "ImgurURL": "${IMGUR_URL}",
         "CFBundleURLTypes": [
             [
                 "CFBundleTypeRole": "Editor",


### PR DESCRIPTION
### What is this PR?
[feature/ #21] 프로필 기입, 수정 관련 네트워크 연결 등

### Changes
- 프로필 관련 네트워크 구현
  - 아카이브 명 관련 네트워크는 확정 시 수정 예정
  - Target 사용 시 Response값이 똑같은 걸로 Request를 묶었습니다
- 중복검사 로직 수정
  - 중복검사 시 버튼 활성화 등 좀 더 자연스러운 UX
- 세팅 - 프로필 수정 화면 네비게이션 처리
- info.plist에 imgur관련 값들이 누락되어있어서 추가했습니다 ㅠㅜ
- 관련 이슈: #21 
<img width="488" alt="스크린샷 2023-03-29 오전 7 24 06" src="https://user-images.githubusercontent.com/62657991/228386180-4d08a72b-ed5e-4952-a5a3-b3286f7a3bdd.png">

<img width="488" alt="스크린샷 2023-03-29 오전 7 59 41" src="https://user-images.githubusercontent.com/62657991/228386192-ed15b4e6-3916-4c85-afaf-12554ef1fd21.png">
