### PR TITLE
[feature, setting/#65, #66] 네트워크 연결, 디자인 재적용, tuist 의존성 변경 등

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -1,102 +1,102 @@
 {
   "pins" : [
     {
-      "identity" : "alamofire",
+      "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Alamofire/Alamofire",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "59037bfd28aa963a7916f1eb22a74107a3522f16",
-        "version" : "5.0.5"
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
       }
     },
     {
-      "identity" : "combine-schedulers",
+      "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
-        "version" : "0.9.1"
+        "revision" : "e700a8f40c87c31cab7984875fcc1225d96b25bf",
+        "version" : "10.11.0"
       }
     },
     {
-      "identity" : "swift-case-paths",
+      "identity" : "googleappmeasurement",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "c3a42e8d1a76ff557cf565ed6d8b0aee0e6e75af",
-        "version" : "0.11.0"
+        "revision" : "62e3a0c09a75e2637f5300d46f05a59313f1c286",
+        "version" : "10.11.0"
       }
     },
     {
-      "identity" : "swift-clocks",
+      "identity" : "googledatatransport",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
-        "version" : "0.2.0"
+        "revision" : "98a00258d4518b7521253a70b7f70bb76d2120fe",
+        "version" : "9.2.4"
       }
     },
     {
-      "identity" : "swift-collections",
+      "identity" : "googleutilities",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "6039a55afc03aac62e898aea4acdbe20d383978c",
+        "version" : "7.11.2"
       }
     },
     {
-      "identity" : "swift-composable-architecture",
+      "identity" : "grpc-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "6cf778a7da64de9508596a435aa0a5647885d71a",
-        "version" : "0.49.2"
+        "revision" : "f1b366129d1125be7db83247e003fc333104b569",
+        "version" : "1.50.2"
       }
     },
     {
-      "identity" : "swift-custom-dump",
+      "identity" : "gtm-session-fetcher",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "ead7d30cc224c3642c150b546f4f1080d1c411a8",
-        "version" : "0.6.1"
+        "revision" : "d415594121c9e8a4f9d79cecee0965cf35e74dbd",
+        "version" : "3.1.1"
       }
     },
     {
-      "identity" : "swift-dependencies",
+      "identity" : "leveldb",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
-        "revision" : "7a094fcc6a4fcb34fbe625ecd3acd81b881a6dfb",
-        "version" : "0.1.3"
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
       }
     },
     {
-      "identity" : "swift-identified-collections",
+      "identity" : "nanopb",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "fd34c544ad27f3ba6b19142b348005bfa85b6005",
-        "version" : "0.6.0"
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
       }
     },
     {
-      "identity" : "swiftui-navigation",
+      "identity" : "promises",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "ddc01cdcddfd30ef7a966049b2e1d251e224ad93",
-        "version" : "0.5.0"
+        "revision" : "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
+        "version" : "2.2.0"
       }
     },
     {
-      "identity" : "xctest-dynamic-overlay",
+      "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "16b23a295fa322eb957af98037f86791449de60f",
-        "version" : "0.8.1"
+        "revision" : "f25867a208f459d3c5a06935dceb9083b11cd539",
+        "version" : "1.22.0"
       }
     }
   ],

--- a/FIMO/Sources/App/GoogleAnalytics.swift
+++ b/FIMO/Sources/App/GoogleAnalytics.swift
@@ -1,0 +1,47 @@
+//
+//  GoogleAnalytics.swift
+//  FIMO
+//
+//  Created by Ok Hyeon Kim on 2023/06/28.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import Foundation
+
+import FirebaseAnalytics
+
+enum AnalyticsEventType: String {
+    case analyticsEventSelectItem
+    case didTapButton
+    case signUp
+    case test
+}
+
+extension AnalyticsEventType {
+    var value: String {
+        switch self {
+        case .analyticsEventSelectItem:
+            return AnalyticsEventSelectItem
+        default:
+            return self.rawValue
+        }
+    }
+}
+
+class GoogleAnalytics {
+    static let shared: GoogleAnalytics = GoogleAnalytics()
+
+    func setUserId(_ id: String) {
+        Analytics.setUserID(id)
+    }
+
+    func logEvent(_ event: AnalyticsEventType) {
+        let parameters = [
+          "file": #file,
+          "function": #function
+        ]
+
+        Analytics.logEvent(event.value, parameters: parameters)
+        Log.info("Send LogEvent: \(event.value), parameters: \(parameters)")
+    }
+}

--- a/FIMO/Sources/App/GoogleAnalytics.swift
+++ b/FIMO/Sources/App/GoogleAnalytics.swift
@@ -10,6 +10,7 @@ import Foundation
 
 import FirebaseAnalytics
 
+// MARK: 이벤트에 맞춰 추가 예정
 enum AnalyticsEventType: String {
     case analyticsEventSelectItem
     case didTapButton

--- a/FIMO/Sources/App/GoogleAnalytics.swift
+++ b/FIMO/Sources/App/GoogleAnalytics.swift
@@ -36,10 +36,10 @@ class GoogleAnalytics {
         Analytics.setUserID(id)
     }
 
-    func logEvent(_ event: AnalyticsEventType) {
+    func logEvent(_ event: AnalyticsEventType, file: String = #file, function: String = #function) {
         let parameters = [
-          "file": #file,
-          "function": #function
+          "file": file,
+          "function": function
         ]
 
         Analytics.logEvent(event.value, parameters: parameters)

--- a/FIMO/Sources/DSKit/Components/Views/LoadingView.swift
+++ b/FIMO/Sources/DSKit/Components/Views/LoadingView.swift
@@ -9,10 +9,18 @@
 import SwiftUI
 
 struct LoadingView: View {
+    var hasOpacity: Bool = false
+
     var body: some View {
         ZStack {
-            Rectangle()
-                .foregroundColor(.white)
+            if hasOpacity {
+                Rectangle()
+                    .foregroundColor(.black)
+                    .opacity(0.3)
+            } else {
+                Rectangle()
+                    .foregroundColor(.white)
+            }
             
             VStack {
                 Spacer()

--- a/FIMO/Sources/Model/Type/Onboarding/OnboardingPageType.swift
+++ b/FIMO/Sources/Model/Type/Onboarding/OnboardingPageType.swift
@@ -8,11 +8,11 @@
 
 import SwiftUI
 
-enum OnboardingPageType: String {
-    case one
-    case two
-    case three
-    case four
+enum OnboardingPageType: Int {
+    case one = 0
+    case two = 1
+    case three = 2
+    case four = 3
 
     var title: String {
         switch self {
@@ -65,10 +65,14 @@ enum OnboardingPageType: String {
             return Image(uiImage: FIMOAsset.Assets.onboardingBackgroundFour.image)
         }
     }
+
+    var index: Int {
+        return self.rawValue
+    }
 }
 
 extension OnboardingPageType: Identifiable, CaseIterable {
     var id: String {
-        self.rawValue
+        return "\(self.rawValue)"
     }
 }

--- a/FIMO/Sources/Model/UIModel/Friend/FriendsListSortType.swift
+++ b/FIMO/Sources/Model/UIModel/Friend/FriendsListSortType.swift
@@ -8,7 +8,13 @@
 
 import Foundation
 
-enum FriendListSortType {
-    case newest
-    case characterOrder
+enum FriendListSortType: String {
+    case created = "CREATED"
+    case alpahabetical = "ALPAHABETICAL"
+}
+
+extension FriendListSortType: CustomStringConvertible {
+    var description: String {
+        return self.rawValue
+    }
 }

--- a/FIMO/Sources/Network/Client/FriendsClient.swift
+++ b/FIMO/Sources/Network/Client/FriendsClient.swift
@@ -26,7 +26,7 @@ extension DependencyValues {
 
 extension FriendsClient: DependencyKey {
     static let liveValue = Self.init { (sortType) in
-        let request = FMFollowMeRequest()
+        let request = FMFollowMeRequest(sortType: sortType)
 
         return BaseNetwork.shared.request(api: request, isInterceptive: true)
             .catchToEffect()

--- a/FIMO/Sources/Network/Client/PostClient.swift
+++ b/FIMO/Sources/Network/Client/PostClient.swift
@@ -1,0 +1,32 @@
+//
+//  PostClient.swift
+//  FIMO
+//
+//  Created by Ok Hyeon Kim on 2023/06/27.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+import ComposableArchitecture
+
+struct PostClient {
+    let uploadPost: (FMUpdatedPost) -> EffectPublisher<Result<FMPostDTO, NetworkError>, Never>
+}
+
+extension DependencyValues {
+    var postClient: PostClient {
+        get { self[PostClient.self] }
+        set { self[PostClient.self] = newValue }
+    }
+}
+
+extension PostClient: DependencyKey {
+    static let liveValue = Self.init { newPostItems in
+        let request = FMCreatePostRequest(newPostItems: newPostItems)
+
+        return BaseNetwork.shared.request(api: request, isInterceptive: true)
+            .catchToEffect()
+    }
+}

--- a/FIMO/Sources/Network/RequestModel/FMFollow/FMFollowMeRequest.swift
+++ b/FIMO/Sources/Network/RequestModel/FMFollow/FMFollowMeRequest.swift
@@ -12,6 +12,7 @@ import Alamofire
 
 struct FMFollowMeRequest: Requestable {
     typealias Response = [FMFriendDTO]
+    let sortType: FriendListSortType
 
     var path: String {
         return "/follow/me"
@@ -21,7 +22,12 @@ struct FMFollowMeRequest: Requestable {
         return .get
     }
 
-    var parameters: Parameters = [:]
+    var parameters: Parameters {
+        return [
+            "sortType": sortType.description
+        ]
+    }
+
 
     var header: [HTTPFields: String] = [
         HTTPFields.authorization: HTTPHeaderType.authorization.header

--- a/FIMO/Sources/View/Acknow/AcknowView.swift
+++ b/FIMO/Sources/View/Acknow/AcknowView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct AcknowView: View {
     var body: some View {
         VStack {
-            CustomNavigationBar(title: "오픈소스 라이선스")
+            CustomNavigationBar(title: "오픈소스 라이선스", isShadowed: true)
 
             AcknowListView()
                 .toolbar(.hidden, for: .navigationBar)

--- a/FIMO/Sources/View/Friends/FriendsListView.swift
+++ b/FIMO/Sources/View/Friends/FriendsListView.swift
@@ -18,7 +18,7 @@ struct FriendsListView: View {
     var body: some View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             VStack(spacing: 0) {
-                CustomNavigationBar(title: viewStore.userName ?? "")
+                CustomNavigationBar(title: viewStore.userName ?? "", isShadowed: true)
 
                 header(viewStore)
 

--- a/FIMO/Sources/View/Friends/FriendsListView.swift
+++ b/FIMO/Sources/View/Friends/FriendsListView.swift
@@ -31,6 +31,9 @@ struct FriendsListView: View {
                     viewStore.send(.refreshFriendList)
                 }
             }
+            .toast(isShowing: viewStore.binding(\.$isShowToast),
+                   title: viewStore.toastMessage.title,
+                   message: viewStore.toastMessage.message)
             .onAppear {
                 viewStore.send(.onAppear)
             }

--- a/FIMO/Sources/View/Friends/FriendsListView.swift
+++ b/FIMO/Sources/View/Friends/FriendsListView.swift
@@ -127,7 +127,7 @@ struct FriendsListView: View {
                     } label: {
                         Text("친구추가순")
                             .foregroundColor(
-                                store.selectedSort == .newest
+                                store.selectedSort == .created
                                 ? Color(FIMOAsset.Assets.red1.color)
                                 : .black
                             )
@@ -140,7 +140,7 @@ struct FriendsListView: View {
                     } label: {
                         Text("가나다순")
                             .foregroundColor(
-                                store.selectedSort == .characterOrder
+                                store.selectedSort == .alpahabetical
                                 ? Color(FIMOAsset.Assets.red1.color)
                                 : .black
                             )

--- a/FIMO/Sources/View/Login/Components/AppleLoginButton.swift
+++ b/FIMO/Sources/View/Login/Components/AppleLoginButton.swift
@@ -82,9 +82,8 @@ extension AppleLoginButton.Coordinator: ASAuthorizationControllerDelegate {
       case let appleIDCredential as ASAuthorizationAppleIDCredential:
           let userID = appleIDCredential.user
           let provider = ASAuthorizationAppleIDProvider()
-          let userName = appleIDCredential.fullName?.formatted() // TODO: 필요없는 경우 제거
           
-          provider.getCredentialState(forUserID: userID) { [weak self] credentialState, _ in
+          provider.getCredentialState(forUserID: userID) { [weak self] credentialState, error in
               guard let self else { return }
               
               switch credentialState {
@@ -100,9 +99,9 @@ extension AppleLoginButton.Coordinator: ASAuthorizationControllerDelegate {
                   print("Apple Login Fail")
                   #endif
                   
-                  self.viewStore.send(.showAlert)
+                  self.viewStore.send(.sendToast(ToastModel(title: error?.localizedDescription ?? "")))
               @unknown default:
-                  self.viewStore.send(.showAlert)
+                  self.viewStore.send(.sendToast(ToastModel(title: error?.localizedDescription ?? "")))
               }
           }
       default:

--- a/FIMO/Sources/View/Login/Components/KakaoLoginButton.swift
+++ b/FIMO/Sources/View/Login/Components/KakaoLoginButton.swift
@@ -43,7 +43,7 @@ struct KakaoLoginButton: UIViewRepresentable {
                     }
 
                     if error != nil {
-                        self.kakaoLoginButton.viewStore.send(.showAlert)
+                        self.kakaoLoginButton.viewStore.send(.sendToast(ToastModel(title: error?.localizedDescription ?? "")))
                     } else {
                         self.requestUserInfo()
                     }
@@ -55,7 +55,7 @@ struct KakaoLoginButton: UIViewRepresentable {
                     }
 
                     if error != nil {
-                        self.kakaoLoginButton.viewStore.send(.showAlert)
+                        self.kakaoLoginButton.viewStore.send(.sendToast(ToastModel(title: error?.localizedDescription ?? "")))
                     } else {
                         self.requestUserInfo()
                     }
@@ -70,7 +70,7 @@ struct KakaoLoginButton: UIViewRepresentable {
                 }
 
                 if let error = error {
-                    self.kakaoLoginButton.viewStore.send(.showAlert)
+                    self.kakaoLoginButton.viewStore.send(.sendToast(ToastModel(title: error.localizedDescription)))
                 } else {
                     let id = String(Int(user?.id ?? 0))
                     self.kakaoLoginButton.action(id)

--- a/FIMO/Sources/View/Login/LoginView.swift
+++ b/FIMO/Sources/View/Login/LoginView.swift
@@ -50,11 +50,6 @@ struct LoginView: View {
                             viewStore.send(.tappedKakaoLoginButton(id))
                         }
                     }
-                    .alert("로그인이 실패했습니다", isPresented: viewStore.binding(\.$isAlertShowing)) {
-                        Button("확인", role: .cancel) {
-                            viewStore.send(.tappedAlertOKButton)
-                        }
-                    }
                     .frame(height: 54)
                     .padding(.top, 0)
                     .padding(.bottom, 18)
@@ -69,11 +64,6 @@ struct LoginView: View {
                                 viewStore.send(.tappedAppleLoginButton(token))
                             }
                         })
-                    .alert("로그인이 실패했습니다", isPresented: viewStore.$isAlertShowing) {
-                        Button("확인", role: .cancel) {
-                            viewStore.send(.tappedAlertOKButton)
-                        }
-                    }
                     .cornerRadius(8)
                     .frame(height: 54)
                     .padding(.top, 0)
@@ -81,6 +71,9 @@ struct LoginView: View {
                     .padding([.leading, .trailing], 16)
                 }
             }
+            .toast(isShowing: viewStore.binding(\.$isShowToast),
+                   title: viewStore.toastMessage.title,
+                   message: viewStore.toastMessage.message)
             .toolbar(.hidden, for: .navigationBar)
         }
         .ignoresSafeArea()

--- a/FIMO/Sources/View/Onboarding/FirstOnboardingView.swift
+++ b/FIMO/Sources/View/Onboarding/FirstOnboardingView.swift
@@ -1,0 +1,59 @@
+//
+//  FirstOnboardingView.swift
+//  FIMO
+//
+//  Created by Ok Hyeon Kim on 2023/06/28.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+struct FirstOnboardingView: View {
+    @EnvironmentObject var sceneDelegate: SceneDelegate
+    let viewStore: ViewStore<OnboardingStore.State, OnboardingStore.Action>
+    let type: OnboardingPageType
+
+    var isOverflowBottomText: Bool {
+        sceneDelegate.window?.bounds.height ?? .zero * 0.35 < 281
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack {
+                Text("")
+                Spacer()
+            }
+            VStack(alignment: .leading, spacing: 0) {
+                Image(uiImage: FIMOAsset.Assets.logo.image)
+                    .padding(.leading, 40)
+                    .padding(.bottom, -20)
+
+                VStack(spacing: 0) {
+                    OnboardingDescriptionView(type: type)
+
+                    Spacer()
+
+                    Rectangle()
+                        .foregroundColor(.clear)
+                        .frame(width: 313, height: 56)
+                        .padding(.bottom, 60)
+                }
+                .if(isOverflowBottomText) { view in
+                    view.frame(height: 281)
+                }
+
+                Spacer()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(
+            OnboardingPageType.one.backgroundImage
+                .resizable()
+                .ignoresSafeArea()
+                .scaledToFill()
+        )
+        .ignoresSafeArea()
+    }
+}

--- a/FIMO/Sources/View/Onboarding/OnboardingCollectionView.swift
+++ b/FIMO/Sources/View/Onboarding/OnboardingCollectionView.swift
@@ -14,7 +14,6 @@ struct OnboardingCollectionView: UIViewRepresentable {
     static let cellIdentifier = "OnboardingViewCollectionViewCell"
     var viewStore: ViewStore<OnboardingStore.State, OnboardingStore.Action>
     let onboardingTypes: [OnboardingPageType] = OnboardingPageType.allCases
-    var currentPage = 0
 
     func makeUIView(context: Context) -> UICollectionView {
         let screenSize = UIScreen.main.bounds.size
@@ -56,7 +55,6 @@ struct OnboardingCollectionView: UIViewRepresentable {
 
         func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OnboardingCollectionView.cellIdentifier, for: indexPath)
-            cell.backgroundColor = .orange
 
             guard let pageType: OnboardingPageType = .init(rawValue: indexPath.row) else {
                 return cell

--- a/FIMO/Sources/View/Onboarding/OnboardingCollectionView.swift
+++ b/FIMO/Sources/View/Onboarding/OnboardingCollectionView.swift
@@ -1,0 +1,86 @@
+//
+//  OnboardingCollectionView.swift
+//  FIMO
+//
+//  Created by Ok Hyeon Kim on 2023/06/28.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+struct OnboardingCollectionView: UIViewRepresentable {
+    static let cellIdentifier = "OnboardingViewCollectionViewCell"
+    var viewStore: ViewStore<OnboardingStore.State, OnboardingStore.Action>
+    let onboardingTypes: [OnboardingPageType] = OnboardingPageType.allCases
+    var currentPage = 0
+
+    func makeUIView(context: Context) -> UICollectionView {
+        let screenSize = UIScreen.main.bounds.size
+        let screenWidth = screenSize.width
+        let screenHeight = screenSize.height
+        let size = CGSize(width: screenWidth, height: screenHeight)
+        let rect = CGRect(origin: .zero, size: size)
+        let layout = UICollectionViewFlowLayout()
+        layout.collectionView?.frame = rect
+        layout.scrollDirection = .horizontal
+        layout.itemSize = size
+        layout.minimumLineSpacing = 0
+        let collectionView = UICollectionView(frame: rect, collectionViewLayout: layout)
+        collectionView.isPagingEnabled = true
+        collectionView.showsHorizontalScrollIndicator = false
+        return collectionView
+    }
+
+    func updateUIView(_ uiView: UICollectionView, context: Context) {
+        uiView.dataSource = context.coordinator
+        uiView.delegate = context.coordinator
+        uiView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: OnboardingCollectionView.cellIdentifier)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, UIScrollViewDelegate {
+        var parent: OnboardingCollectionView
+
+        init(_ parent: OnboardingCollectionView) {
+            self.parent = parent
+        }
+
+        func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+            return parent.onboardingTypes.count
+        }
+
+        func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OnboardingCollectionView.cellIdentifier, for: indexPath)
+            cell.backgroundColor = .orange
+
+            guard let pageType: OnboardingPageType = .init(rawValue: indexPath.row) else {
+                return cell
+            }
+
+            cell.contentConfiguration = UIHostingConfiguration {
+                if pageType == .one {
+                    FirstOnboardingView(viewStore: parent.viewStore, type: pageType)
+                } else {
+                    OtherOnboardingView(viewStore: parent.viewStore, type: pageType)
+                }
+            }.margins(.all, 0)
+
+            return cell
+        }
+
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            let currentPageIndex = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
+            guard currentPageIndex != parent.viewStore.pageType.index,
+                  let pageType = OnboardingPageType(rawValue: currentPageIndex) else {
+                return
+            }
+
+            parent.viewStore.send(.changePage(pageType))
+        }
+    }
+}

--- a/FIMO/Sources/View/Onboarding/OnboardingStore.swift
+++ b/FIMO/Sources/View/Onboarding/OnboardingStore.swift
@@ -20,12 +20,16 @@ struct OnboardingStore: ReducerProtocol {
         case binding(BindingAction<State>)
         case startButtonTapped
         case skipButtonTapped
+        case changePage(OnboardingPageType)
     }
 
     var body: some ReducerProtocol<State, Action> {
         BindingReducer()
         Reduce { state, action in
             switch action {
+            case .changePage(let pageType):
+                state.pageType = pageType
+                return .none
             default:
                 return .none
             }

--- a/FIMO/Sources/View/Onboarding/OnboardingView.swift
+++ b/FIMO/Sources/View/Onboarding/OnboardingView.swift
@@ -14,154 +14,31 @@ struct OnboardingView: View {
     @EnvironmentObject var sceneDelegate: SceneDelegate
     let store: StoreOf<OnboardingStore>
 
-    var isOverflowBottomText: Bool {
-        sceneDelegate.window?.bounds.height ?? .zero * 0.35 < 281
-    }
-
     var body: some View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             ZStack {
                 Color.white
                     .ignoresSafeArea()
 
-                TabView(selection: viewStore.binding(\.$pageType)) {
-                    firstOnboardingView(viewStore: viewStore, type: .one)
-                        .tag(OnboardingPageType.one)
+                OnboardingCollectionView(viewStore: viewStore)
+                    .ignoresSafeArea()
+                    .tabViewStyle(.page(indexDisplayMode: .never))
+                    .animation(.easeInOut, value: viewStore.pageType)
+                    .transition(.opacity)
+                    .zIndex(1)
 
-                    ForEach([OnboardingPageType.two, .three, .four], id: \.self) { type in
-                        otherOnboardingView(viewStore: viewStore, type: type)
-                            .tag(type)
-                    }
-                }
-                .ignoresSafeArea()
-                .if(viewStore.pageType == .one) {
-                    $0.background(
-                        viewStore.pageType.backgroundImage
-                            .resizable()
-                            .ignoresSafeArea()
-                            .scaledToFill()
-                    )
-                }
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .animation(.easeInOut, value: viewStore.pageType)
-                .transition(.opacity)
-
-                if viewStore.pageType != .four {
-                    ZStack {
+                ZStack {
+                    if viewStore.pageType != .four {
                         skipButton(viewStore: viewStore)
-
                         indexDisplay(viewStore: viewStore)
                     }
-                    .transition(.opacity)
-                    .animation(.easeInOut, value: viewStore.pageType)
-                    .zIndex(1)
                 }
+                .transition(.opacity)
+                .animation(.easeInOut, value: viewStore.pageType)
+                .zIndex(2)
             }
             .ignoresSafeArea()
             .zIndex(0)
-        }
-    }
-
-    @ViewBuilder func firstOnboardingView(viewStore: ViewStore<OnboardingStore.State, OnboardingStore.Action>, type: OnboardingPageType) -> some View {
-        VStack(spacing: 0) {
-            VStack {
-                Text("")
-                Spacer()
-            }
-            VStack(alignment: .leading, spacing: 0) {
-                Image(uiImage: FIMOAsset.Assets.logo.image)
-                    .padding(.leading, 40)
-                    .padding(.bottom, -20)
-
-                VStack(spacing: 0) {
-                    OnboardingDescriptionView(type: type)
-
-                    Spacer()
-
-                    Rectangle()
-                        .foregroundColor(.clear)
-                        .frame(width: 313, height: 56)
-                        .padding(.bottom, 60)
-                }
-                .if(isOverflowBottomText) { view in
-                    view.frame(height: 281)
-                }
-
-                Spacer()
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .ignoresSafeArea()
-        .background(
-            OnboardingPageType.one.backgroundImage
-                .resizable()
-                .ignoresSafeArea()
-                .scaledToFill()
-        )
-    }
-
-    @ViewBuilder func otherOnboardingView(viewStore: ViewStore<OnboardingStore.State, OnboardingStore.Action>, type: OnboardingPageType) -> some View {
-        VStack(spacing: 0) {
-            VStack {
-                Spacer()
-                viewStore.pageType.backgroundImage
-                    .resizable()
-                    .frame(maxHeight: .infinity)
-                    .padding(.top, 40)
-                    .aspectRatio(contentMode: .fit)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(FIMOAsset.Assets.gray1.color))
-
-            VStack(alignment: .leading, spacing: 0) {
-                VStack(spacing: 0) {
-                    OnboardingDescriptionView(type: type)
-
-                    Spacer()
-
-                    if viewStore.pageType == .four {
-                        startButton(viewStore: viewStore)
-                    } else {
-                        Rectangle()
-                            .foregroundColor(.clear)
-                            .frame(width: 313, height: 56)
-                            .padding(.bottom, 60)
-                    }
-                }
-                .if(isOverflowBottomText) { view in
-                    view.frame(height: 281)
-                }
-
-                Spacer()
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .ignoresSafeArea()
-            .background(Color.white)
-        }
-        .ignoresSafeArea()
-    }
-
-    func startButton(viewStore: ViewStore<OnboardingStore.State, OnboardingStore.Action>) -> some View {
-        VStack(alignment: .center) {
-            Button {
-                viewStore.send(.startButtonTapped)
-            } label: {
-                HStack(spacing: 0) {
-                    Image(uiImage: FIMOAsset.Assets.simpleLogo.image)
-                        .resizable()
-                        .frame(width: 30, height: 20)
-
-                    Text(viewStore.isAgainGuideReview ? "돌아가기" : "피모 시작하기")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.white)
-                        .padding(14)
-
-                }
-                .frame(width: 313, height: 56)
-                .background(Color.black)
-                .cornerRadius(4)
-            }
-            .padding(.bottom, 60)
         }
     }
 

--- a/FIMO/Sources/View/Onboarding/OtherOnboardingView.swift
+++ b/FIMO/Sources/View/Onboarding/OtherOnboardingView.swift
@@ -1,0 +1,86 @@
+//
+//  OtherOnboardingView.swift
+//  FIMO
+//
+//  Created by Ok Hyeon Kim on 2023/06/28.
+//  Copyright © 2023 pimo. All rights reserved.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+struct OtherOnboardingView: View {
+    @EnvironmentObject var sceneDelegate: SceneDelegate
+    let viewStore: ViewStore<OnboardingStore.State, OnboardingStore.Action>
+    let type: OnboardingPageType
+
+    var isOverflowBottomText: Bool {
+        sceneDelegate.window?.bounds.height ?? .zero * 0.35 < 281
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack {
+                Spacer()
+                type.backgroundImage
+                    .resizable()
+                    .frame(maxHeight: .infinity)
+                    .padding(.top, 40)
+                    .aspectRatio(contentMode: .fit)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(FIMOAsset.Assets.gray1.color))
+
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(spacing: 0) {
+                    OnboardingDescriptionView(type: type)
+
+                    Spacer()
+
+                    if type == .four {
+                        startButton(viewStore: viewStore)
+                    } else {
+                        Rectangle()
+                            .foregroundColor(.clear)
+                            .frame(width: 313, height: 56)
+                            .padding(.bottom, 60)
+                    }
+                }
+                .if(isOverflowBottomText) { view in
+                    view.frame(height: 281)
+                }
+
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.white)
+            .ignoresSafeArea()
+        }
+        .ignoresSafeArea()
+    }
+
+    func startButton(viewStore: ViewStore<OnboardingStore.State, OnboardingStore.Action>) -> some View {
+        VStack(alignment: .center) {
+            Button {
+                viewStore.send(.startButtonTapped)
+            } label: {
+                HStack(spacing: 0) {
+                    Image(uiImage: FIMOAsset.Assets.simpleLogo.image)
+                        .resizable()
+                        .frame(width: 30, height: 20)
+
+                    Text(viewStore.isAgainGuideReview ? "돌아가기" : "피모 시작하기")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.white)
+                        .padding(14)
+
+                }
+                .frame(width: 313, height: 56)
+                .background(Color.black)
+                .cornerRadius(4)
+            }
+            .padding(.bottom, 60)
+        }
+    }
+}

--- a/FIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
+++ b/FIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
@@ -17,7 +17,7 @@ struct ModifyProfileView: View {
     var body: some View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             VStack(alignment: .leading, spacing: 0) {
-                CustomNavigationBar(title: "프로필 수정") {
+                CustomNavigationBar(title: "프로필 수정", isShadowed: true) {
                     viewStore.send(.tappedBackButton)
                 }
 

--- a/FIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
+++ b/FIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
@@ -53,6 +53,9 @@ struct ModifyProfileView: View {
                 }
                 .padding(.horizontal, 20)
             }
+            .toast(isShowing: viewStore.binding(\.$isShowToast),
+                   title: viewStore.toastMessage.title,
+                   message: viewStore.toastMessage.message)
             .sheet(isPresented: viewStore.binding(\.$isShowImagePicker)) {
                 ImagePicker { uiImage in
                     viewStore.send(.selectProfileImage(uiImage))

--- a/FIMO/Sources/View/Setting/SettingView.swift
+++ b/FIMO/Sources/View/Setting/SettingView.swift
@@ -17,7 +17,7 @@ struct SettingView: View {
     var body: some View {
         WithViewStore(self.store, observe: { $0 }) { viewStore in
             VStack(alignment: .leading) {
-                CustomNavigationBar(title: "설정")
+                CustomNavigationBar(title: "설정", isShadowed: true)
 
                 HStack(alignment: .center) {
                     KFImage(URL(string: viewStore.profile.profileImageUrl))
@@ -29,7 +29,7 @@ struct SettingView: View {
                                 .font(.system(size: 40))
                         })
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: 40, height: 40)
+                        .frame(width: 52, height: 52)
                         .mask {
                             Circle()
                         }

--- a/FIMO/Sources/View/Setting/SettingView.swift
+++ b/FIMO/Sources/View/Setting/SettingView.swift
@@ -131,6 +131,9 @@ struct SettingView: View {
                 }
                 .padding(.horizontal, 20)
             }
+            .toast(isShowing: viewStore.binding(\.$isShowToast),
+                   title: viewStore.toastMessage.title,
+                   message: viewStore.toastMessage.message)
             .backPopup(isShowing: viewStore.binding(\.$isShowBackPopup), store: viewStore)
             .fullScreenCover(isPresented: viewStore.binding(\.$isSheetPresented)) {
                 IfLetStore(

--- a/FIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/FIMO/Sources/View/TabBar/TabBarStore.swift
@@ -87,6 +87,8 @@ struct TabBarStore: ReducerProtocol {
                 switch result {
                 case .success(let myProfile):
                     state.myProfile = myProfile.toModel()
+                    GoogleAnalytics.shared.setUserId(myProfile.id)
+                    GoogleAnalytics.shared.logEvent(.test)
                 case .failure(let error):
                     state.toastMessage = .init(title: error.errorDescription ?? "")
                     state.isShowToast = true

--- a/FIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/FIMO/Sources/View/TabBar/TabBarStore.swift
@@ -214,6 +214,11 @@ struct TabBarStore: ReducerProtocol {
                         Action.archive(.deleteFeed($0))
                     }
                 }
+            case .upload(.didTapPublishButtonDone(let result)):
+                if case .success = result {
+                    state.isSheetPresented = false
+                }
+                return .none
             default:
                 return .none
             }

--- a/FIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/FIMO/Sources/View/TabBar/TabBarStore.swift
@@ -93,6 +93,7 @@ struct TabBarStore: ReducerProtocol {
                     state.isShowToast = true
                 }
             case .setSheetState:
+                GoogleAnalytics.shared.logEvent(.test)
                 state.isSheetPresented = true
             case .upload(.didTapCloseButton):
                 state.isSheetPresented = false

--- a/FIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/FIMO/Sources/View/TabBar/TabBarStore.swift
@@ -88,7 +88,6 @@ struct TabBarStore: ReducerProtocol {
                 case .success(let myProfile):
                     state.myProfile = myProfile.toModel()
                     GoogleAnalytics.shared.setUserId(myProfile.id)
-                    GoogleAnalytics.shared.logEvent(.test)
                 case .failure(let error):
                     state.toastMessage = .init(title: error.errorDescription ?? "")
                     state.isShowToast = true

--- a/FIMO/Sources/View/Upload/Model/UploadImage.swift
+++ b/FIMO/Sources/View/Upload/Model/UploadImage.swift
@@ -8,18 +8,27 @@
 
 import SwiftUI
 
-final class UploadImage: Identifiable, Equatable {
+struct UploadImage {
     var id: Int
     let image: UIImage
     let text: String
+    var imageUrl: String?
     
     init(id: Int, image: UIImage, text: String = "") {
         self.id = id
         self.image = image
         self.text = text
+        self.imageUrl = nil
     }
-    
-    static func == (lhs: UploadImage, rhs: UploadImage) -> Bool {
-        lhs.id == rhs.id
+}
+
+extension UploadImage: Identifiable, Equatable {
+    func toUpdatedPostItem() -> FMUpdatedPostItem {
+        guard let imageUrl = imageUrl else {
+            Log.error("이미지 URL이 누락되어 있습니다. \(id)")
+            return .init(imageUrl: "", content: text)
+        }
+
+        return .init(imageUrl: imageUrl, content: text)
     }
 }

--- a/FIMO/Sources/View/Upload/UploadView.swift
+++ b/FIMO/Sources/View/Upload/UploadView.swift
@@ -18,28 +18,34 @@ struct UploadView: View {
         WithViewStore(store, observe: { $0 }) { viewStore in
             let screenWidth = sceneDelegate.window?.bounds.width ?? 0
             
-            VStack {
-                topBar(viewStore: viewStore, screenWidth: screenWidth)
-                    .shadow(
-                        color: Color(FIMOAsset.Assets.grayShadow.color).opacity(0.1),
-                        radius: 3,
-                        x: 0,
-                        y: 3
-                    )
-                    .padding(.bottom, 20)
-                
-                photoUploader(viewStore: viewStore)
-                    .frame(width: screenWidth - 40, height: 88)
-                    .padding(.bottom, 38)
-                
-                mainImage(viewStore: viewStore)
-                    .frame(width: 353, height: 353)
-                    
-                Spacer()
-                
-                publishButton(viewStore: viewStore)
-                    .padding(.bottom, 60)
-                    .frame(width: 353, height: 56)
+            ZStack {
+                VStack {
+                    topBar(viewStore: viewStore, screenWidth: screenWidth)
+                        .shadow(
+                            color: Color(FIMOAsset.Assets.grayShadow.color).opacity(0.1),
+                            radius: 3,
+                            x: 0,
+                            y: 3
+                        )
+                        .padding(.bottom, 20)
+
+                    photoUploader(viewStore: viewStore)
+                        .frame(width: screenWidth - 40, height: 88)
+                        .padding(.bottom, 38)
+
+                    mainImage(viewStore: viewStore)
+                        .frame(width: 353, height: 353)
+
+                    Spacer()
+
+                    publishButton(viewStore: viewStore)
+                        .padding(.bottom, 60)
+                        .frame(width: 353, height: 56)
+                }
+
+                if viewStore.isLoading {
+                    LoadingView(hasOpacity: true)
+                }
             }
             .modifier(ClosePopupViewModifier(
                 viewStore: viewStore,

--- a/FIMO/Sources/View/Upload/UploadView.swift
+++ b/FIMO/Sources/View/Upload/UploadView.swift
@@ -45,11 +45,12 @@ struct UploadView: View {
 
                 if viewStore.isLoading {
                     LoadingView(hasOpacity: true)
+                        .ignoresSafeArea()
                 }
             }
             .modifier(ClosePopupViewModifier(
                 viewStore: viewStore,
-                isShowing: viewStore.binding(\.$isClose)
+                isShowing: viewStore.binding(\.$isIncompleteClose)
             ))
             .toast(
                 isShowing: viewStore.binding(\.$isShowOCRErrorToast),

--- a/Plugins/EnvPlugin/ProjectDescriptionHelpers/Environment.swift
+++ b/Plugins/EnvPlugin/ProjectDescriptionHelpers/Environment.swift
@@ -1,7 +1,7 @@
 import ProjectDescription
 
 public enum Environment {
-    public static let bundleId: String = "com.nexters.ios.pimo"
-    public static let organizationName: String = "pimo"
+    public static let bundleId: String = "com.nexters.ios.fimo"
+    public static let organizationName: String = "fimo"
     public static let deploymentTarget: DeploymentTarget = .iOS(targetVersion: "16.0", devices: [.iphone])
 }

--- a/Plugins/EnvPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
+++ b/Plugins/EnvPlugin/ProjectDescriptionHelpers/SettingsDictionary+.swift
@@ -8,7 +8,7 @@ public extension SettingsDictionary {
     func setCodeSignManual() -> SettingsDictionary {
         return merging([
             "CODE_SIGN_STYLE": SettingValue(stringLiteral: "Manual"),
-            "DEVELOPMENT_TEAM": SettingValue(stringLiteral: "FA464JRW3F"),
+            "DEVELOPMENT_TEAM": SettingValue(stringLiteral: "NY37VGJ3HF"),
             "CODE_SIGN_IDENTITY": SettingValue(stringLiteral: "$(CODE_SIGN_IDENTITY)")
         ])
     }

--- a/Project.swift
+++ b/Project.swift
@@ -11,6 +11,6 @@ let project = Project.app(
         .external(name: "AcknowList"),
         .external(name: "KakaoSDK"),
         .external(name: "FLAnimatedImage"),
-        .external(name: "FirebaseDynamicLinks"),
-        .external(name: "FirebaseAnalytics")
+        .package(product: "FirebaseAnalytics"),
+        .package(product: "FirebaseCrashlytics")
     ])

--- a/Project.swift
+++ b/Project.swift
@@ -12,5 +12,5 @@ let project = Project.app(
         .external(name: "KakaoSDK"),
         .external(name: "FLAnimatedImage"),
         .package(product: "FirebaseAnalytics"),
-        .package(product: "FirebaseCrashlytics")
+        .package(product: "FirebaseDynamicLinks")
     ])

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -6,8 +6,7 @@ let spm = SwiftPackageManagerDependencies([
     .remote(url: "https://github.com/onevcat/Kingfisher", requirement: .upToNextMajor(from: "7.6.1")),
     .remote(url: "https://github.com/vtourraine/AcknowList", requirement: .upToNextMajor(from: "3.0.0")),
     .remote(url: "https://github.com/kakao/kakao-ios-sdk", requirement: .upToNextMajor(from: "2.13.1")),
-    .remote(url: "https://github.com/Flipboard/FLAnimatedImage", requirement: .upToNextMajor(from: "1.0.17")),
-    .remote(url: "https://github.com/firebase/firebase-ios-sdk", requirement: .upToNextMajor(from:"10.7.0")),
+    .remote(url: "https://github.com/Flipboard/FLAnimatedImage", requirement: .upToNextMajor(from: "1.0.17"))
 ])
 
 let dependencies = Dependencies(

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -14,6 +14,7 @@ extension Project {
             platform: platform,
             product: .app,
             bundleId: "\(Environment.bundleId)",
+            deploymentTarget: Environment.deploymentTarget,
             infoPlist: .extendingDefault(with: Project.infoPlist),
             sources: ["\(name)/Sources/**"],
             resources: ["\(name)/Resources/**", "Tuist/Dependencies/Lockfiles/Package.resolved"],

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -19,7 +19,8 @@ extension Project {
             resources: ["\(name)/Resources/**", "Tuist/Dependencies/Lockfiles/Package.resolved"],
             entitlements: "\(name)/\(name).entitlements",
             scripts: [.SwiftLintShell],
-            dependencies: dependencies
+            dependencies: dependencies,
+            launchArguments: [LaunchArgument(name: "-FIRDebugEnabled", isEnabled: true)]
         )
         
         let testTarget = Target(
@@ -44,6 +45,9 @@ extension Project {
         return Project(
             name: name,
             organizationName: Environment.organizationName,
+            packages: [
+                .remote(url: "https://github.com/firebase/firebase-ios-sdk", requirement: .upToNextMajor(from:"10.7.0"))
+            ],
             settings: .settings(base: baseSettings, configurations: configSettings),
             targets: targets
         )


### PR DESCRIPTION
### What is this PR?
[feature, setting/#65, #66] 네트워크 연결, 디자인 재적용, tuist 의존성 변경 등

### Changes
- 포스트 업로드 네트워크 구현
  - 업로드 후 home, archive에 업로드한 포스트 추가 필요
- 누락된 toast ViewModifier 구현
- friendList Sort 조건 기능 구현

<img width="489" alt="스크린샷 2023-06-28 오후 3 10 43" src="https://github.com/Nexters-PIMO/FIMO_iOS/assets/62657991/2f158757-e875-4a9a-add9-171a75116a36">


- OnboardingView 어색한 페이징 수정
  - UIViewRepresentable, UICollectionView 활용
  - SwiftUI에서는 geometryReader를 활용해 뎁스가 깊어지므로 UIKit, UIViewRepresentable 활용


![화면 기록 2023-06-28 오후 3 15 46](https://github.com/Nexters-PIMO/FIMO_iOS/assets/62657991/8c245f02-ae51-4001-8d3b-f640fd514256)


- 디자인 수정
- firebase 의존성 변경, GoogleAnalytics manager 구현
  - crash로 정적 라이브러리로 변경
  - 빠른 로그 반영을 위해 빌드 옵션 추가
  - `tuist clean` 후 `tusit fetch`, `tuist generate` 필요
- 인증서 공유 및 bundle ID 변경 `com.nexters.ios.fimo`, tuist 설정


### 이후
- 배포 준비
- Follow 화면에서 해당 사용자 탭하면 해당 사용자 저장소로 push
