### PR TITLE
[feature, fix] 프로필 정보 기입 유효성검사 수정, 홈, 아카이브 피드 네트워크 연결

### DIFF
--- a/FIMO/Sources/Core/Extension/String+Date.swift
+++ b/FIMO/Sources/Core/Extension/String+Date.swift
@@ -17,7 +17,7 @@ extension String {
     
     func toUploadTime() -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyyMMddHHmmss"
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
         
         guard let date = dateFormatter.date(from: self) else {
             return "-"

--- a/FIMO/Sources/Core/Modifiers/Popup/RemovePopup.swift
+++ b/FIMO/Sources/Core/Modifiers/Popup/RemovePopup.swift
@@ -55,7 +55,7 @@ struct RemovePopupViewModifier: ViewModifier {
                     }, type: .cancel),
                     PopupButton(buttonText: "삭제하기", buttonCompletionHandler: {
                         isShowing = false
-                        store.send(.deleteFeed)
+                        store.send(.deletePost)
                     }, type: .destructive)
                 ])
         }

--- a/FIMO/Sources/DSKit/Components/BottomSheet/BottomSheetStore.swift
+++ b/FIMO/Sources/DSKit/Components/BottomSheet/BottomSheetStore.swift
@@ -12,15 +12,15 @@ import ComposableArchitecture
 
 struct BottomSheetStore: ReducerProtocol {
     struct State: Equatable {
-        var feedId: Int = 0
-        var feed: Feed = .EMPTY
+        var postId: String = ""
+        var post: FMPost = .EMPTY
         var bottomSheetType: BottomSheetType = .me
     }
     
     enum Action: Equatable {
-        case editButtonDidTap(Feed)
-        case deleteButtonDidTap(Int)
-        case declationButtonDidTap(Int)
+        case editButtonDidTap(FMPost)
+        case deleteButtonDidTap(String)
+        case declationButtonDidTap(String)
     }
     
     var body: some ReducerProtocol<State, Action> {

--- a/FIMO/Sources/DSKit/Components/BottomSheet/BottomSheetView.swift
+++ b/FIMO/Sources/DSKit/Components/BottomSheet/BottomSheetView.swift
@@ -22,7 +22,7 @@ struct BottomSheetView: View {
                 if viewStore.bottomSheetType == .me {
                     bottomSheetText(text: "수정하기")
                         .onTapGesture {
-                            viewStore.send(.editButtonDidTap(viewStore.feed))
+                            viewStore.send(.editButtonDidTap(viewStore.post))
                         }
                     
                     Spacer()
@@ -30,12 +30,12 @@ struct BottomSheetView: View {
                     
                     bottomSheetText(text: "삭제하기")
                         .onTapGesture {
-                            viewStore.send(.deleteButtonDidTap((viewStore.feedId)))
+                            viewStore.send(.deleteButtonDidTap((viewStore.postId)))
                         }
                 } else {
                     bottomSheetText(text: "신고하기")
                         .onTapGesture {
-                            viewStore.send(.declationButtonDidTap((viewStore.feedId)))
+                            viewStore.send(.declationButtonDidTap((viewStore.postId)))
                         }
                 }
             }

--- a/FIMO/Sources/Model/Type/ProfileSetting/CheckValidationType.swift
+++ b/FIMO/Sources/Model/Type/ProfileSetting/CheckValidationType.swift
@@ -33,7 +33,7 @@ extension CheckValidationType: CustomStringConvertible {
         case .blank:
             return ""
         case .beforeDuplicateCheck:
-            return  ""
+            return "중복 확인이 필요해요"
         case .alreadyUsedNickname:
             return "이미 사용 중인 닉네임이에요"
         case .alreadyUsedArchiveName:

--- a/FIMO/Sources/Model/Type/ProfileSetting/CheckValidationType.swift
+++ b/FIMO/Sources/Model/Type/ProfileSetting/CheckValidationType.swift
@@ -8,12 +8,13 @@
 
 import SwiftUI
 
-enum CheckValidationType {
+enum CheckValidationType: String {
     case availableNickName
     case availableArchiveName
     case onlyKoreanEnglishAndNumber
     case exceededCharacters
     case blank
+    case sameName
     case beforeDuplicateCheck
     case alreadyUsedNickname
     case alreadyUsedArchiveName
@@ -30,10 +31,8 @@ extension CheckValidationType: CustomStringConvertible {
             return "한글과 영어, 숫자만 사용할 수 있어요"
         case .exceededCharacters:
             return "글자 수를 초과했어요"
-        case .blank:
+        case .blank, .beforeDuplicateCheck, .sameName:
             return ""
-        case .beforeDuplicateCheck:
-            return "중복 확인이 필요해요"
         case .alreadyUsedNickname:
             return "이미 사용 중인 닉네임이에요"
         case .alreadyUsedArchiveName:
@@ -41,7 +40,47 @@ extension CheckValidationType: CustomStringConvertible {
         }
     }
 
-    var color: Color {
+    var isDuplicateButtonEnabled: Bool {
+        switch self {
+        case .beforeDuplicateCheck, .availableNickName, .availableArchiveName:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isBlankField: Bool {
+        return self == .blank
+    }
+
+    var isOKButtonClickable: Bool {
+        switch self {
+        case .availableNickName, .availableArchiveName:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var fieldColor: Color {
+        switch self {
+        case .blank:
+            return Color(FIMOAsset.Assets.gray1.color)
+        default:
+            return Color.black
+        }
+    }
+
+    var duplicatedButtonColor: Color {
+        switch self {
+        case .beforeDuplicateCheck, .availableNickName, .availableArchiveName:
+            return Color.black
+        default:
+            return Color(FIMOAsset.Assets.gray1.color)
+        }
+    }
+
+    var descriptionColor: Color {
         switch self {
         case .alreadyUsedNickname, .exceededCharacters, .onlyKoreanEnglishAndNumber:
             return Color(FIMOAsset.Assets.red1.color)

--- a/FIMO/Sources/Model/UIModel/FMPost/FMPost.swift
+++ b/FIMO/Sources/Model/UIModel/FMPost/FMPost.swift
@@ -8,11 +8,28 @@
 
 import Foundation
 
-struct FMPost: Equatable {
+struct FMPost {
     let id: String
     let user: FMPostUser
     let favorite: Int
     let isClicked: Bool
     let createdAt: String
     let items: [FMPostItem]
+}
+
+extension FMPost: Hashable, Equatable {
+    static let EMPTY: FMPost = {
+        return .init(
+            id: "",
+            user: .init(
+                id: "",
+                nickname: "",
+                archiveName: ""
+            ),
+            favorite: 0,
+            isClicked: false,
+            createdAt: "",
+            items: [FMPostItem]()
+        )
+    }()
 }

--- a/FIMO/Sources/Model/UIModel/FMPost/FMPostItem.swift
+++ b/FIMO/Sources/Model/UIModel/FMPost/FMPostItem.swift
@@ -8,7 +8,13 @@
 
 import Foundation
 
-struct FMPostItem: Equatable {
+struct FMPostItem {
     let imageUrl: String
     let content: String
+}
+
+extension FMPostItem: Hashable, Equatable {
+    static let EMPTY: FMPostItem = {
+        return .init(imageUrl: "", content: "")
+    }()
 }

--- a/FIMO/Sources/Model/UIModel/FMPost/FMPostItem.swift
+++ b/FIMO/Sources/Model/UIModel/FMPost/FMPostItem.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct FMPostItem {
+    let id: UUID = UUID()
     let imageUrl: String
     let content: String
 }

--- a/FIMO/Sources/Model/UIModel/FMPost/FMPostUser.swift
+++ b/FIMO/Sources/Model/UIModel/FMPost/FMPostUser.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 
-struct FMPostUser: Equatable {
+struct FMPostUser {
     let id: String
     let nickname: String
     let archiveName: String
 }
+
+extension FMPostUser: Equatable, Hashable { }

--- a/FIMO/Sources/Network/Client/ArchiveClient.swift
+++ b/FIMO/Sources/Network/Client/ArchiveClient.swift
@@ -12,9 +12,13 @@ import Foundation
 import ComposableArchitecture
 
 struct ArchiveClient {
+    #warning("새로운 API로 삭제 예정")
     let fetchProfile: () -> EffectPublisher<Result<Profile, NetworkError>, Never>
     let fetchArchiveFeeds: () -> EffectPublisher<Result<[FeedDTO], NetworkError>, Never>
     let fetchFeed: (Int) -> EffectPublisher<Result<FeedDTO, NetworkError>, Never>
+
+    let archivePosts: () -> EffectPublisher<Result<[FMPostDTO], NetworkError>, Never>
+    let post: (String) -> EffectPublisher<Result<FMPostDTO, NetworkError>, Never>
 }
 
 extension DependencyValues {
@@ -40,6 +44,16 @@ extension ArchiveClient: DependencyKey {
             let request = FeedRequest(feedId: feedId)
             
             return BaseNetwork.shared.request(api: request, isInterceptive: false)
+                .catchToEffect()
+        }, archivePosts: {
+            let request = FMAllPostRequest(target: .me)
+
+            return BaseNetwork.shared.request(api: request, isInterceptive: true)
+                .catchToEffect()
+        }, post: { id in
+            let request = FMPostDetailRequest(postId: id)
+
+            return BaseNetwork.shared.request(api: request, isInterceptive: true)
                 .catchToEffect()
         }
     )

--- a/FIMO/Sources/Network/Client/FeedClient.swift
+++ b/FIMO/Sources/Network/Client/FeedClient.swift
@@ -14,8 +14,13 @@ import ComposableArchitecture
 struct FeedClient {
     let play: (String) -> EffectPublisher<Void, Never>
     let stop: () -> EffectPublisher<Void, Never>
+
+    #warning("새로운 API로 제거 예정")
     let postClap: (Int) -> EffectPublisher<Result<Bool, NetworkError>, Never>
     let deleteFeed: (Int) -> EffectPublisher<Result<Bool, NetworkError>, Never>
+
+    let clap: (String) -> EffectPublisher<Result<Int, NetworkError>, Never>
+    let deletePost: (String) -> EffectPublisher<Result<FMServerDescriptionDTO, NetworkError>, Never>
 }
 
 extension DependencyValues {
@@ -40,6 +45,16 @@ extension FeedClient: DependencyKey {
                 let request = FeedActionRequest(target: .deleteFeed(feedId))
                 
                 return BaseNetwork.shared.requestWithNoResponse(api: request, isInterceptive: false)
+                    .catchToEffect()
+            }, clap: { id in
+                let request = FMPostFavoriteRequest(postId: id)
+
+                return BaseNetwork.shared.request(api: request, isInterceptive: false)
+                    .catchToEffect()
+            }, deletePost: { id in
+                let request = FMDeletePostRequest(postId: id)
+
+                return BaseNetwork.shared.request(api: request, isInterceptive: false)
                     .catchToEffect()
             }
         )

--- a/FIMO/Sources/Network/Client/HomeClient.swift
+++ b/FIMO/Sources/Network/Client/HomeClient.swift
@@ -12,7 +12,10 @@ import Foundation
 import ComposableArchitecture
 
 struct HomeClient {
+    #warning("새로운 API로 삭제 예정")
     let fetchFeeds: () -> EffectPublisher<Result<[FeedDTO], NetworkError>, Never>
+
+    let posts: () -> EffectPublisher<Result<[FMPostDTO], NetworkError>, Never>
 }
 
 extension DependencyValues {
@@ -27,6 +30,11 @@ extension HomeClient: DependencyKey {
         fetchFeeds: {
             let request = FeedsRequest(target: .fetchHomeFeeds)
             
+            return BaseNetwork.shared.request(api: request, isInterceptive: false)
+                .catchToEffect()
+        }, posts: {
+            let request = FMAllFeedRequest()
+
             return BaseNetwork.shared.request(api: request, isInterceptive: false)
                 .catchToEffect()
         })

--- a/FIMO/Sources/Network/RequestModel/FMPost/FMAllPostRequest.swift
+++ b/FIMO/Sources/Network/RequestModel/FMPost/FMAllPostRequest.swift
@@ -22,7 +22,7 @@ struct FMAllPostRequest: Requestable {
     var path: String {
         switch target {
         case .me:
-            return "/post/"
+            return "/post"
         case .another(let userId):
             return "/post/user/\(userId)"
         }

--- a/FIMO/Sources/Network/RequestModel/FMPost/FMDeletePostRequest.swift
+++ b/FIMO/Sources/Network/RequestModel/FMPost/FMDeletePostRequest.swift
@@ -11,8 +11,8 @@ import Foundation
 import Alamofire
 
 struct FMDeletePostRequest: Requestable {
-    typealias Response = Empty
-    let postId: Int
+    typealias Response = FMServerDescriptionDTO
+    let postId: String
 
     var path: String {
         return "/post/delete/\(postId)"

--- a/FIMO/Sources/Network/RequestModel/FMPost/FMPostDetailRequest.swift
+++ b/FIMO/Sources/Network/RequestModel/FMPost/FMPostDetailRequest.swift
@@ -12,7 +12,7 @@ import Alamofire
 
 struct FMPostDetailRequest: Requestable {
     typealias Response = FMPostDTO
-    let postId: Int
+    let postId: String
 
     var path: String {
         return "/post/detail/\(postId)"

--- a/FIMO/Sources/Network/RequestModel/FMPost/FMPostDetailRequest.swift
+++ b/FIMO/Sources/Network/RequestModel/FMPost/FMPostDetailRequest.swift
@@ -15,7 +15,7 @@ struct FMPostDetailRequest: Requestable {
     let postId: String
 
     var path: String {
-        return "/post/detail/\(postId)"
+        return "/post/details/\(postId)"
     }
 
     var method: HTTPMethod {

--- a/FIMO/Sources/Network/RequestModel/FMPost/FMPostFavoriteRequest.swift
+++ b/FIMO/Sources/Network/RequestModel/FMPost/FMPostFavoriteRequest.swift
@@ -12,7 +12,7 @@ import Alamofire
 
 struct FMPostFavoriteRequest: Requestable {
     typealias Response = Int
-    let postId: Int
+    let postId: String
 
     var path: String {
         return "/post/favorite/\(postId)"

--- a/FIMO/Sources/View/Archive/ArchiveStore.swift
+++ b/FIMO/Sources/View/Archive/ArchiveStore.swift
@@ -234,8 +234,11 @@ struct ArchiveStore: ReducerProtocol {
             case .setting(.tappedProfileManagementButton):
                 state.profile = ProfileSettingStore.State(
                     nickname: state.setting?.profile.nickname ?? "",
+                    previousNickname: state.setting?.profile.nickname ?? "",
                     archiveName: state.setting?.profile.archiveName ?? "",
-                    selectedImageURL: state.setting?.profile.profileImageUrl ?? ""
+                    previousArchiveName: state.setting?.profile.archiveName ?? "",
+                    selectedImageURL: state.setting?.profile.profileImageUrl ?? "",
+                    previousSelectedImageURL: state.setting?.profile.profileImageUrl ?? ""
                 )
                 state.path.append(.modifyProfile)
             case let .deleteFeed(result):

--- a/FIMO/Sources/View/Archive/ArchiveView.swift
+++ b/FIMO/Sources/View/Archive/ArchiveView.swift
@@ -90,9 +90,9 @@ struct ArchiveView: View {
             }
             
             IfLetStore(
-                self.store.scope(state: \.feed, action: { .feedDetail($0) })
+                self.store.scope(state: \.post, action: { .postDetail($0) })
             ) {
-                feedDetail(viewStore, feedStore: $0)
+                postDetail(viewStore, postStore: $0)
             } else: {
                 if viewStore.feedsType == .basic {
                     basicFeedView(viewStore)
@@ -109,15 +109,15 @@ struct ArchiveView: View {
     // 피드 기본 모드로 보기
     func basicFeedView(_ viewStore: ViewStore<ArchiveStore.State, ArchiveStore.Action>) -> some View {
         LazyVStack(alignment: .center, pinnedViews: [.sectionHeaders]) {
-            Section(header: feedsHeader(viewStore)) {
-                if viewStore.feeds.isEmpty {
+            Section(header: postsHeader(viewStore)) {
+                if viewStore.posts.isEmpty {
                     ArchiveEmptyView(archiveType: viewStore.archiveType)
                         .frame(height: UIScreen.screenHeight - 350)
                 } else {
                     ForEachStore(
                         self.store.scope(
-                            state: \.feeds,
-                            action: ArchiveStore.Action.feed(id:action:)
+                            state: \.posts,
+                            action: ArchiveStore.Action.post(id:action:)
                         )
                     ) {
                         FeedView(store: $0)
@@ -137,19 +137,19 @@ struct ArchiveView: View {
     // 피드 그리드 모드로 보기
     func gridFeedView(_ viewStore: ViewStore<ArchiveStore.State, ArchiveStore.Action>) -> some View {
         LazyVGrid(
-            columns: viewStore.feeds.isEmpty
+            columns: viewStore.posts.isEmpty
             ? [GridItem(.flexible())] : columns,
             alignment: .center,
             spacing: 5,
             pinnedViews: [.sectionHeaders]
         ) {
-            Section(header: feedsHeader(viewStore)) {
-                if viewStore.feeds.isEmpty {
+            Section(header: postsHeader(viewStore)) {
+                if viewStore.posts.isEmpty {
                     ArchiveEmptyView(archiveType: viewStore.archiveType)
                         .frame(height: UIScreen.screenHeight - 344)
                 } else {
-                    ForEach(viewStore.state.gridFeeds, id: \.self) { feed in
-                        KFImage(URL(string: feed.textImages[0].imageURL))
+                    ForEach(viewStore.state.gridPosts, id: \.self) { post in
+                        KFImage(URL(string: post.items[0].imageUrl))
                             .placeholder {
                                 Rectangle()
                                     .foregroundColor(.gray)
@@ -157,7 +157,7 @@ struct ArchiveView: View {
                             .resizable()
                             .frame(height: width/2)
                             .onTapGesture {
-                                viewStore.send(.feedDidTap(feed.id))
+                                viewStore.send(.postDidTap(post.id))
                             }
                     }
                 }
@@ -166,7 +166,7 @@ struct ArchiveView: View {
     }
     
     // 글사진 상세
-    func feedDetail(_ viewStore: ViewStore<ArchiveStore.State, ArchiveStore.Action>, feedStore: Store<FeedStore.State, FeedStore.Action>) -> some View {
+    func postDetail(_ viewStore: ViewStore<ArchiveStore.State, ArchiveStore.Action>, postStore: Store<PostStore.State, PostStore.Action>) -> some View {
         VStack {
             Rectangle()
                 .fill(Color.white)
@@ -201,7 +201,7 @@ struct ArchiveView: View {
                 .background(Color(FIMOAsset.Assets.grayDivider.color))
                 .padding([.leading, .trailing], 20)
             
-            FeedView(store: feedStore)
+            FeedView(store: postStore)
             
             Spacer()
                 .frame(height: 16)
@@ -230,7 +230,7 @@ struct ArchiveView: View {
                 Text(viewStore.archiveProfile.nickname)
                     .font(Font(FIMOFontFamily.Pretendard.medium.font(size: 16)))
                 
-                Text(FIMOStrings.archivingTextImage(viewStore.feeds.count))
+                Text(FIMOStrings.archivingTextImage(viewStore.posts.count))
                     .font(Font(FIMOFontFamily.Pretendard.regular.font(size: 14)))
                     .foregroundColor(Color(FIMOAsset.Assets.grayText.color))
             }
@@ -253,11 +253,11 @@ struct ArchiveView: View {
     }
     
     // 아카이브 상단 글 사진 뷰
-    func feedsHeader(_ viewStore: ViewStore<ArchiveStore.State, ArchiveStore.Action>) -> some View {
+    func postsHeader(_ viewStore: ViewStore<ArchiveStore.State, ArchiveStore.Action>) -> some View {
         HStack {
             Image(uiImage: FIMOAsset.Assets.archiveLogo.image)
             
-            Text(FIMOStrings.textImageTitle(viewStore.feeds.count))
+            Text(FIMOStrings.textImageTitle(viewStore.posts.count))
                 .font(Font(FIMOFontFamily.Pretendard.medium.font(size: 16)))
                 .foregroundColor(.black)
             

--- a/FIMO/Sources/View/Archive/ArchiveView.swift
+++ b/FIMO/Sources/View/Archive/ArchiveView.swift
@@ -120,7 +120,7 @@ struct ArchiveView: View {
                             action: ArchiveStore.Action.post(id:action:)
                         )
                     ) {
-                        FeedView(store: $0)
+                        PostView(store: $0)
                         
                         Spacer()
                             .frame(height: 12)
@@ -201,7 +201,7 @@ struct ArchiveView: View {
                 .background(Color(FIMOAsset.Assets.grayDivider.color))
                 .padding([.leading, .trailing], 20)
             
-            FeedView(store: postStore)
+            PostView(store: postStore)
             
             Spacer()
                 .frame(height: 16)

--- a/FIMO/Sources/View/Feed/Components/FeedTextImageView.swift
+++ b/FIMO/Sources/View/Feed/Components/FeedTextImageView.swift
@@ -11,14 +11,14 @@ import SwiftUI
 import Kingfisher
 
 struct FeedTextImageView: View {
-    private let textImage: TextImage
+    private let postItem: FMPostItem
     
-    init(textImage: TextImage) {
-        self.textImage = textImage
+    init(postItem: FMPostItem) {
+        self.postItem = postItem
     }
     
     var body: some View {
-        KFImage(URL(string: textImage.imageURL))
+        KFImage(URL(string: postItem.imageUrl))
             .placeholder { Image(systemName: "person.fill") }
             .resizable()
             .aspectRatio(contentMode: .fill)
@@ -27,9 +27,11 @@ struct FeedTextImageView: View {
 
 struct FeedTextImageView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedTextImageView(textImage: TextImage(
-            id: 1,
-            imageURL: FIMOStrings.textImage,
-            text: "안녕"))
+        FeedTextImageView(
+            postItem: FMPostItem(
+                imageUrl: FIMOStrings.textImage,
+                content: "안녕"
+            )
+        )
     }
 }

--- a/FIMO/Sources/View/Feed/Components/PostTextImageView.swift
+++ b/FIMO/Sources/View/Feed/Components/PostTextImageView.swift
@@ -1,5 +1,5 @@
 //
-//  FeedTextImageView.swift
+//  PostTextImageView.swift
 //  PIMO
 //
 //  Created by 김영인 on 2023/02/21.
@@ -10,7 +10,7 @@ import SwiftUI
 
 import Kingfisher
 
-struct FeedTextImageView: View {
+struct PostTextImageView: View {
     private let postItem: FMPostItem
     
     init(postItem: FMPostItem) {
@@ -25,9 +25,9 @@ struct FeedTextImageView: View {
     }
 }
 
-struct FeedTextImageView_Previews: PreviewProvider {
+struct PostTextImageView_Previews: PreviewProvider {
     static var previews: some View {
-        FeedTextImageView(
+        PostTextImageView(
             postItem: FMPostItem(
                 imageUrl: FIMOStrings.textImage,
                 content: "안녕"

--- a/FIMO/Sources/View/Feed/FeedView.swift
+++ b/FIMO/Sources/View/Feed/FeedView.swift
@@ -12,7 +12,7 @@ import ComposableArchitecture
 import Kingfisher
 
 struct FeedView: View {
-    let store: StoreOf<FeedStore>
+    let store: StoreOf<PostStore>
     
     let width = UIScreen.screenWidth - 40
     
@@ -24,7 +24,8 @@ struct FeedView: View {
                 VStack {
                     // 피드 상단
                     HStack {
-                        KFImage(URL(string: viewStore.feed.user.profileImage))
+                        #warning("프로필 이미지 추가 필요")
+                        KFImage(URL(string: viewStore.post.user.archiveName))
                             .placeholder { Image(systemName: "person") }
                             .resizable()
                             .aspectRatio(contentMode: .fill)
@@ -36,12 +37,12 @@ struct FeedView: View {
                         Spacer()
                             .frame(width: 12)
                         
-                        Text(viewStore.feed.user.nickName)
+                        Text(viewStore.post.user.nickname)
                             .font(.system(size: 14, weight: .medium))
                         
                         Spacer()
                         
-                        Text(viewStore.feed.uploadTime)
+                        Text(viewStore.post.createdAt)
                             .foregroundColor(Color(FIMOAsset.Assets.grayText.color))
                             .font(.system(size: 14))
                         
@@ -61,8 +62,8 @@ struct FeedView: View {
                     // 글사진
                     ZStack {
                         TabView(selection: viewStore.binding(\.$textImage)) {
-                            ForEach(viewStore.feed.textImages, id: \.self) {
-                                FeedTextImageView(textImage: $0)
+                            ForEach(viewStore.post.items, id: \.self) {
+                                FeedTextImageView(postItem: $0)
                                     .tag($0)
                             }
                         }
@@ -104,10 +105,10 @@ struct FeedView: View {
     }
     
     // 텍스트 복사 버튼
-    func textCopyButton(_ viewStore: ViewStore<FeedStore.State, FeedStore.Action>) -> some View {
+    func textCopyButton(_ viewStore: ViewStore<PostStore.State, PostStore.Action>) -> some View {
         HStack(spacing: 4) {
             Button {
-                viewStore.send(.copyButtonDidTap(viewStore.state.textImage.text))
+                viewStore.send(.copyButtonDidTap(viewStore.state.textImage.content))
             } label: {
                 ZStack {
                     Circle()
@@ -118,7 +119,7 @@ struct FeedView: View {
                 }
             }
             
-            if !viewStore.state.closeButtonDidTap && viewStore.state.isFirstFeed {
+            if !viewStore.state.closeButtonDidTap && viewStore.state.isFirstPost {
                 textGuideView(viewStore)
             }
         }
@@ -127,7 +128,7 @@ struct FeedView: View {
     }
     
     // 텍스트 복사하기 가이드 뷰
-    func textGuideView(_ viewStore: ViewStore<FeedStore.State, FeedStore.Action>) -> some View {
+    func textGuideView(_ viewStore: ViewStore<PostStore.State, PostStore.Action>) -> some View {
         ZStack {
             Image(uiImage: FIMOAsset.Assets.textCopy.image)
             
@@ -153,10 +154,10 @@ struct FeedView: View {
     
     // 글 사진 하단 인덱스 뷰
     @ViewBuilder
-    func indexDisplay(_ viewStore: ViewStore<FeedStore.State, FeedStore.Action>) -> some View {
-        if viewStore.feed.textImages.count > 1 {
+    func indexDisplay(_ viewStore: ViewStore<PostStore.State, PostStore.Action>) -> some View {
+        if viewStore.post.items.count > 1 {
             HStack(spacing: 4) {
-                ForEach(viewStore.feed.textImages, id: \.self) {
+                ForEach(viewStore.post.items, id: \.self) {
                     Circle()
                         .frame(width: 4, height: 4)
                         .foregroundColor(
@@ -170,7 +171,7 @@ struct FeedView: View {
     }
     
     // 박수 버튼
-    func clapButton(_ viewStore: ViewStore<FeedStore.State, FeedStore.Action>) -> some View {
+    func clapButton(_ viewStore: ViewStore<PostStore.State, PostStore.Action>) -> some View {
         Button {
             plusButtonTimer?.cancel()
             viewStore.send(.clapButtonDidTap)
@@ -210,7 +211,7 @@ struct FeedView: View {
     }
     
     // 박수 +0 버튼
-    func clapPlusView(_ viewStore: ViewStore<FeedStore.State, FeedStore.Action>) -> some View {
+    func clapPlusView(_ viewStore: ViewStore<PostStore.State, PostStore.Action>) -> some View {
         ZStack {
             if viewStore.state.plusClapCount !=  0 {
                 Circle()
@@ -229,7 +230,7 @@ struct FeedView: View {
     }
     
     // 공유하기 버튼
-    func shareButton(_ viewStore: ViewStore<FeedStore.State, FeedStore.Action>) -> some View {
+    func shareButton(_ viewStore: ViewStore<PostStore.State, PostStore.Action>) -> some View {
         Button {
             viewStore.send(.shareButtonDidTap)
         } label: {
@@ -245,9 +246,9 @@ struct FeedView: View {
     }
     
     // 오디오 버튼
-    func audioButton(_ viewStore: ViewStore<FeedStore.State, FeedStore.Action>) -> some View {
+    func audioButton(_ viewStore: ViewStore<PostStore.State, PostStore.Action>) -> some View {
         Button {
-            let text = viewStore.state.textImage.text
+            let text = viewStore.state.textImage.content
             viewStore.send(.audioButtonDidTap(text))
         } label: {
             if viewStore.audioButtonDidTap {

--- a/FIMO/Sources/View/Feed/PostStore.swift
+++ b/FIMO/Sources/View/Feed/PostStore.swift
@@ -10,12 +10,12 @@ import Foundation
 
 import ComposableArchitecture
 
-struct FeedStore: ReducerProtocol {
+struct PostStore: ReducerProtocol {
     struct State: Equatable, Identifiable {
-        @BindingState var textImage: TextImage = TextImage.EMPTY
-        var id: Int = 0
-        var feed: Feed = Feed.EMPTY
-        var isFirstFeed: Bool = false
+        @BindingState var textImage: FMPostItem = FMPostItem.EMPTY
+        var id: String = ""
+        var post: FMPost = FMPost.EMPTY
+        var isFirstPost: Bool = false
         var clapCount: Int = 0
         var plusClapCount: Int = 0
         var isClapped: Bool = false
@@ -28,11 +28,11 @@ struct FeedStore: ReducerProtocol {
     enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
         case checkTextGuideClosed
-        case moreButtonDidTap(Int)
+        case moreButtonDidTap(String)
         case copyButtonDidTap(String)
         case closeButtonDidTap
         case clapButtonDidTap
-        case postClap(Result<Bool, NetworkError>)
+        case postClap(Result<Int, NetworkError>)
         case clapButtonIsDone
         case shareButtonDidTap
         case audioButtonDidTap(String)
@@ -59,7 +59,7 @@ struct FeedStore: ReducerProtocol {
                 state.clapCount += 1
                 state.clapButtonDidTap = true
                 state.isClapPlusViewShowing = true
-                return feedClient.postClap(state.id).map {
+                return feedClient.clap(state.id).map {
                     Action.postClap($0)
                 }
             case let .postClap(result):

--- a/FIMO/Sources/View/Feed/PostStore.swift
+++ b/FIMO/Sources/View/Feed/PostStore.swift
@@ -1,5 +1,5 @@
 //
-//  FeedStore.swift
+//  PostStore.swift
 //  PIMO
 //
 //  Created by 김영인 on 2023/02/24.

--- a/FIMO/Sources/View/Feed/PostView.swift
+++ b/FIMO/Sources/View/Feed/PostView.swift
@@ -42,7 +42,7 @@ struct PostView: View {
                         
                         Spacer()
                         
-                        Text(viewStore.post.createdAt)
+                        Text(viewStore.post.createdAt.toUploadTime())
                             .foregroundColor(Color(FIMOAsset.Assets.grayText.color))
                             .font(.system(size: 14))
                         

--- a/FIMO/Sources/View/Feed/PostView.swift
+++ b/FIMO/Sources/View/Feed/PostView.swift
@@ -1,5 +1,5 @@
 //
-//  FeedView.swift
+//  PostView.swift
 //  PIMO
 //
 //  Created by 김영인 on 2023/02/18.
@@ -11,7 +11,7 @@ import SwiftUI
 import ComposableArchitecture
 import Kingfisher
 
-struct FeedView: View {
+struct PostView: View {
     let store: StoreOf<PostStore>
     
     let width = UIScreen.screenWidth - 40
@@ -63,7 +63,7 @@ struct FeedView: View {
                     ZStack {
                         TabView(selection: viewStore.binding(\.$textImage)) {
                             ForEach(viewStore.post.items, id: \.self) {
-                                FeedTextImageView(postItem: $0)
+                                PostTextImageView(postItem: $0)
                                     .tag($0)
                             }
                         }

--- a/FIMO/Sources/View/Home/Components/HomeTopBar.swift
+++ b/FIMO/Sources/View/Home/Components/HomeTopBar.swift
@@ -15,7 +15,7 @@ extension HomeView {
         let postCount: Int
         
         init(_ state: HomeStore.State) {
-            self.postCount = state.feeds.count
+            self.postCount = state.posts.count
         }
     }
     

--- a/FIMO/Sources/View/Home/HomeStore.swift
+++ b/FIMO/Sources/View/Home/HomeStore.swift
@@ -152,8 +152,11 @@ struct HomeStore: ReducerProtocol {
             case .setting(.tappedProfileManagementButton):
                 state.profile = ProfileSettingStore.State(
                     nickname: state.setting?.profile.nickname ?? "",
+                    previousNickname: state.setting?.profile.nickname ?? "",
                     archiveName: state.setting?.profile.archiveName ?? "",
-                    selectedImageURL: state.setting?.profile.profileImageUrl ?? ""
+                    previousArchiveName: state.setting?.profile.archiveName ?? "",
+                    selectedImageURL: state.setting?.profile.profileImageUrl ?? "",
+                    previousSelectedImageURL: state.setting?.profile.profileImageUrl ?? ""
                 )
                 state.path.append(.modifyProfile)
             default:

--- a/FIMO/Sources/View/Home/HomeView.swift
+++ b/FIMO/Sources/View/Home/HomeView.swift
@@ -22,7 +22,7 @@ struct HomeView: View {
                     
                     if viewStore.isLoading {
                         LoadingView()
-                    } else if viewStore.feeds.isEmpty {
+                    } else if viewStore.posts.isEmpty {
                         homeWelcome
                             .refreshable {
                                 viewStore.send(.refresh)
@@ -79,8 +79,8 @@ struct HomeView: View {
                 LazyVStack {
                     ForEachStore(
                         self.store.scope(
-                            state: \.feeds,
-                            action: HomeStore.Action.feed(id:action:)
+                            state: \.posts,
+                            action: HomeStore.Action.post(id:action:)
                         )
                     ) {
                         FeedView(store: $0)

--- a/FIMO/Sources/View/Home/HomeView.swift
+++ b/FIMO/Sources/View/Home/HomeView.swift
@@ -28,7 +28,7 @@ struct HomeView: View {
                                 viewStore.send(.refresh)
                             }
                     } else {
-                        homeFeedView(viewStore: viewStore)
+                        homePostView(viewStore: viewStore)
                             .refreshable {
                                 viewStore.send(.refresh)
                             }
@@ -73,7 +73,7 @@ struct HomeView: View {
         }
     }
     
-    func homeFeedView(viewStore: ViewStore<HomeStore.State, HomeStore.Action>) -> some View {
+    func homePostView(viewStore: ViewStore<HomeStore.State, HomeStore.Action>) -> some View {
         ScrollView {
             LazyVStack(alignment: .center) {
                 LazyVStack {
@@ -83,7 +83,7 @@ struct HomeView: View {
                             action: HomeStore.Action.post(id:action:)
                         )
                     ) {
-                        FeedView(store: $0)
+                        PostView(store: $0)
                         
                         Spacer()
                             .frame(height: 12)

--- a/FIMO/Sources/View/ProfileSetting/ArchiveSettingView.swift
+++ b/FIMO/Sources/View/ProfileSetting/ArchiveSettingView.swift
@@ -40,7 +40,7 @@ struct ArchiveSettingView: View {
                     Text(viewStore.archiveValidationType.description)
                         .padding(.top, 10)
                         .font(.system(size: 12))
-                        .foregroundColor(viewStore.archiveValidationType.color)
+                        .foregroundColor(viewStore.archiveValidationType.descriptionColor)
 
                     nextButton(viewStore)
                 }
@@ -61,13 +61,13 @@ struct ArchiveSettingView: View {
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity, minHeight: 56)
                 .background(
-                    viewStore.isActiveButtonOnArchive
+                    viewStore.archiveValidationType.isOKButtonClickable
                     ? Color(FIMOAsset.Assets.red2.color)
                     : Color(FIMOAsset.Assets.gray1.color)
                     )
                 .cornerRadius(2)
         }
-        .disabled(!viewStore.isActiveButtonOnArchive)
+        .disabled(!viewStore.archiveValidationType.isOKButtonClickable)
         .padding(.top, 34)
     }
 
@@ -76,7 +76,7 @@ struct ArchiveSettingView: View {
             TextField("텍스트를 입력해주세요.", text: viewStore.binding(\.$archiveName))
                 .padding()
                 .foregroundColor(
-                    fieldColor(isBlackArchiveField: viewStore.isBlackArchiveField)
+                    viewStore.archiveValidationType.fieldColor
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 2)
@@ -95,25 +95,21 @@ struct ArchiveSettingView: View {
                         Text("중복확인")
                             .font(.system(size: 16))
                             .foregroundColor(
-                                fieldColor(isBlackArchiveField: viewStore.isBlackArchiveField)
+                                viewStore.archiveValidationType.duplicatedButtonColor
                             )
 
                         Divider()
                             .frame(width: 60)
                             .background(
-                                fieldColor(isBlackArchiveField: viewStore.isBlackArchiveField)
+                                viewStore.archiveValidationType.duplicatedButtonColor
                             )
                     }
 
                 }
-                .disabled(viewStore.isBlackArchiveField)
+                .disabled(!viewStore.archiveValidationType.isDuplicateButtonEnabled)
                 .padding(.trailing, 21)
             }
         }
-    }
-
-    func fieldColor(isBlackArchiveField: Bool) -> Color {
-        return isBlackArchiveField ? Color(FIMOAsset.Assets.gray1.color) : Color.black
     }
 }
 

--- a/FIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
+++ b/FIMO/Sources/View/ProfileSetting/ModifyProfileView.swift
@@ -34,7 +34,7 @@ struct ModifyProfileView: View {
                     Text(viewStore.nicknameValidationType.description)
                         .padding(.top, 10)
                         .font(.system(size: 12))
-                        .foregroundColor(viewStore.nicknameValidationType.color)
+                        .foregroundColor(viewStore.nicknameValidationType.descriptionColor)
 
                     Text("아카이브 이름")
                         .font(.system(size: 16))
@@ -45,7 +45,7 @@ struct ModifyProfileView: View {
                     Text(viewStore.archiveValidationType.description)
                         .padding(.top, 10)
                         .font(.system(size: 12))
-                        .foregroundColor(viewStore.archiveValidationType.color)
+                        .foregroundColor(viewStore.archiveValidationType.descriptionColor)
 
                     Spacer()
 
@@ -121,13 +121,25 @@ struct ModifyProfileView: View {
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity, minHeight: 56)
                 .background(
-                    viewStore.isChangedInfo
+                    viewStore.nicknameValidationType.isOKButtonClickable ||
+                    viewStore.archiveValidationType.isOKButtonClickable && (
+                        viewStore.nicknameValidationType == .sameName ||
+                        viewStore.archiveValidationType == .sameName
+                    )
                     ? Color(FIMOAsset.Assets.red2.color)
                     : Color(FIMOAsset.Assets.gray1.color)
-                    )
+                )
                 .cornerRadius(2)
         }
-        .disabled(!viewStore.isChangedInfo)
+        .disabled(
+            !(
+                viewStore.nicknameValidationType.isOKButtonClickable ||
+                viewStore.archiveValidationType.isOKButtonClickable && (
+                    viewStore.nicknameValidationType == .sameName ||
+                    viewStore.archiveValidationType == .sameName
+                )
+            )
+        )
         .padding(.top, 34)
         .padding(.bottom, 60)
     }
@@ -137,7 +149,7 @@ struct ModifyProfileView: View {
             TextField("텍스트를 입력해주세요.", text: viewStore.binding(\.$nickname))
                 .padding()
                 .foregroundColor(
-                    fieldColor(isBlack: viewStore.isBlackNicknameField)
+                    viewStore.nicknameValidationType.fieldColor
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 2)
@@ -156,18 +168,18 @@ struct ModifyProfileView: View {
                         Text("중복확인")
                             .font(.system(size: 16))
                             .foregroundColor(
-                                fieldColor(isBlack: viewStore.isBlackNicknameField)
+                                viewStore.nicknameValidationType.duplicatedButtonColor
                             )
 
                         Divider()
                             .frame(width: 60)
                             .background(
-                                fieldColor(isBlack: viewStore.isBlackNicknameField)
+                                viewStore.nicknameValidationType.duplicatedButtonColor
                             )
                     }
 
                 }
-                .disabled(viewStore.isBlackNicknameField)
+                .disabled(!viewStore.nicknameValidationType.isDuplicateButtonEnabled)
                 .padding(.trailing, 21)
                 .padding(.top, 13)
             }
@@ -179,7 +191,7 @@ struct ModifyProfileView: View {
             TextField("텍스트를 입력해주세요.", text: viewStore.binding(\.$archiveName))
                 .padding()
                 .foregroundColor(
-                    fieldColor(isBlack: viewStore.isBlackArchiveField)
+                    viewStore.archiveValidationType.fieldColor
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 2)
@@ -198,26 +210,22 @@ struct ModifyProfileView: View {
                         Text("중복확인")
                             .font(.system(size: 16))
                             .foregroundColor(
-                                fieldColor(isBlack: viewStore.isBlackArchiveField)
+                                viewStore.archiveValidationType.duplicatedButtonColor
                             )
 
                         Divider()
                             .frame(width: 60)
                             .background(
-                                fieldColor(isBlack: viewStore.isBlackArchiveField)
+                                viewStore.archiveValidationType.duplicatedButtonColor
                             )
                     }
 
                 }
-                .disabled(viewStore.isBlackArchiveField)
+                .disabled(!viewStore.archiveValidationType.isDuplicateButtonEnabled)
                 .padding(.trailing, 21)
                 .padding(.top, 13)
             }
         }
-    }
-
-    func fieldColor(isBlack: Bool) -> Color {
-        return isBlack ? Color(FIMOAsset.Assets.gray1.color) : Color.black
     }
 }
 

--- a/FIMO/Sources/View/ProfileSetting/NicknameSettingView.swift
+++ b/FIMO/Sources/View/ProfileSetting/NicknameSettingView.swift
@@ -40,7 +40,7 @@ struct NicknameSettingView: View {
                     Text(viewStore.nicknameValidationType.description)
                         .padding(.top, 10)
                         .font(.system(size: 12))
-                        .foregroundColor(viewStore.nicknameValidationType.color)
+                        .foregroundColor(viewStore.nicknameValidationType.descriptionColor)
 
                     nextButton(viewStore)
                 }
@@ -61,13 +61,13 @@ struct NicknameSettingView: View {
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity, minHeight: 56)
                 .background(
-                    viewStore.isActiveButtonOnNickname
+                    viewStore.nicknameValidationType.isOKButtonClickable
                     ? Color(FIMOAsset.Assets.red2.color)
                     : Color(FIMOAsset.Assets.gray1.color)
                     )
                 .cornerRadius(2)
         }
-        .disabled(!viewStore.isActiveButtonOnNickname)
+        .disabled(!viewStore.nicknameValidationType.isOKButtonClickable)
         .padding(.top, 34)
     }
 
@@ -76,7 +76,7 @@ struct NicknameSettingView: View {
             TextField("텍스트를 입력해주세요.", text: viewStore.binding(\.$nickname))
                 .padding()
                 .foregroundColor(
-                    fieldColor(isBlackNicknameField: viewStore.isBlackNicknameField)
+                    viewStore.nicknameValidationType.fieldColor
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 2)
@@ -95,25 +95,21 @@ struct NicknameSettingView: View {
                         Text("중복확인")
                             .font(.system(size: 16))
                             .foregroundColor(
-                                fieldColor(isBlackNicknameField: viewStore.isBlackNicknameField)
+                                viewStore.nicknameValidationType.duplicatedButtonColor
                             )
 
                         Divider()
                             .frame(width: 60)
                             .background(
-                                fieldColor(isBlackNicknameField: viewStore.isBlackNicknameField)
+                                viewStore.nicknameValidationType.duplicatedButtonColor
                             )
                     }
 
                 }
-                .disabled(viewStore.isBlackNicknameField)
+                .disabled(!viewStore.nicknameValidationType.isDuplicateButtonEnabled)
                 .padding(.trailing, 21)
             }
         }
-    }
-
-    func fieldColor(isBlackNicknameField: Bool) -> Color {
-        return isBlackNicknameField ? Color(FIMOAsset.Assets.gray1.color) : Color.black
     }
 }
 

--- a/FIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/FIMO/Sources/View/TabBar/TabBarStore.swift
@@ -137,6 +137,8 @@ struct TabBarStore: ReducerProtocol {
                 case let .dismissBottomSheet(post):
                     print(post)
                     state.isSheetPresented = true
+                    state.uploadState.uploadedPostItems = post.items
+                    state.uploadState.selectedPostItem = post.items.first
                 case .setting(.tappedLogoutButton):
                     state.isShowLogoutPopup = true
                 case .setting(.tappedWithdrawalButton):
@@ -167,9 +169,10 @@ struct TabBarStore: ReducerProtocol {
                     state.isShowRemovePopup = true
                     state.postId = postId
                     state.deleteAt = .archive
-                case let .dismissBottomSheet(feed):
-                    print(feed)
+                case let .dismissBottomSheet(post):
                     state.isSheetPresented = true
+                    state.uploadState.uploadedPostItems = post.items
+                    state.uploadState.selectedPostItem = post.items.first
                 case .setting(.tappedLogoutButton):
                     state.isShowLogoutPopup = true
                 case .setting(.tappedWithdrawalButton):

--- a/FIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/FIMO/Sources/View/TabBar/TabBarStore.swift
@@ -224,6 +224,13 @@ struct TabBarStore: ReducerProtocol {
             case .upload(.didTapPublishButtonDone(let result)):
                 if case .success = result {
                     state.isSheetPresented = false
+
+                    let effects: [EffectTask<TabBarStore.Action>] = [
+                        .init(value: .home(.onAppear)),
+                        .init(value: .archive(.onAppear))
+                    ]
+
+                    return .merge(effects)
                 }
                 return .none
             default:

--- a/FIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/FIMO/Sources/View/TabBar/TabBarStore.swift
@@ -101,12 +101,14 @@ struct TabBarStore: ReducerProtocol {
                 return .send(.home(.receiveProfileInfo(state.myProfile ?? FMProfile.EMPTY)))
             case .home(.bottomSheet(.deleteButtonDidTap(let postId))):
                 state.isShowRemovePopup = true
-                let _ = print(postId)
+                state.postId = postId
+                state.deleteAt = .home
             case .archive(.settingButtonDidTap):
                 return .send(.archive(.receiveProfileInfo(state.myProfile ?? FMProfile.EMPTY)))
             case .archive(.bottomSheet(.deleteButtonDidTap(let postId))):
                 state.isShowRemovePopup = true
-                let _ = print(postId)
+                state.postId = postId
+                state.deleteAt = .archive
             case .acceptBackOnProfileSetting:
                 if state.tabBarItem == .home,
                    state.homeState.path.last == .modifyProfile {

--- a/FIMO/Sources/View/TabBar/TabBarStore.swift
+++ b/FIMO/Sources/View/TabBar/TabBarStore.swift
@@ -31,7 +31,7 @@ struct TabBarStore: ReducerProtocol {
         var homeState = HomeStore.State()
         var uploadState = UploadStore.State()
         var archiveState = ArchiveStore.State()
-        var feedId: Int?
+        var postId: String?
         var deleteAt: DeleteAt?
         var selectedFriend: FMFriend?
     }
@@ -46,7 +46,7 @@ struct TabBarStore: ReducerProtocol {
         case home(HomeStore.Action)
         case upload(UploadStore.Action)
         case archive(ArchiveStore.Action)
-        case deleteFeed
+        case deletePost
         case acceptBackOnProfileSetting
         case acceptLogout
         case acceptWithdrawal
@@ -99,14 +99,14 @@ struct TabBarStore: ReducerProtocol {
                 state.isSheetPresented = false
             case .home(.settingButtonDidTap):
                 return .send(.home(.receiveProfileInfo(state.myProfile ?? FMProfile.EMPTY)))
-            case .home(.bottomSheet(.deleteButtonDidTap(let feedId))):
+            case .home(.bottomSheet(.deleteButtonDidTap(let postId))):
                 state.isShowRemovePopup = true
-                let _ = print(feedId)
+                let _ = print(postId)
             case .archive(.settingButtonDidTap):
                 return .send(.archive(.receiveProfileInfo(state.myProfile ?? FMProfile.EMPTY)))
-            case .archive(.bottomSheet(.deleteButtonDidTap(let feedId))):
+            case .archive(.bottomSheet(.deleteButtonDidTap(let postId))):
                 state.isShowRemovePopup = true
-                let _ = print(feedId)
+                let _ = print(postId)
             case .acceptBackOnProfileSetting:
                 if state.tabBarItem == .home,
                    state.homeState.path.last == .modifyProfile {
@@ -128,12 +128,12 @@ struct TabBarStore: ReducerProtocol {
                 switch action {
                 case .settingButtonDidTap:
                     return .send(.home(.receiveProfileInfo(state.myProfile ?? FMProfile.EMPTY)))
-                case let .bottomSheet(.deleteButtonDidTap(feedId)):
+                case let .bottomSheet(.deleteButtonDidTap(postId)):
                     state.isShowRemovePopup = true
-                    state.feedId = feedId
+                    state.postId = postId
                     state.deleteAt = .home
-                case let .dismissBottomSheet(feed):
-                    print(feed)
+                case let .dismissBottomSheet(post):
+                    print(post)
                     state.isSheetPresented = true
                 case .setting(.tappedLogoutButton):
                     state.isShowLogoutPopup = true
@@ -161,9 +161,9 @@ struct TabBarStore: ReducerProtocol {
                 switch action {
                 case .settingButtonDidTap:
                     return .send(.archive(.receiveProfileInfo(state.myProfile ?? FMProfile.EMPTY)))
-                case let .bottomSheet(.deleteButtonDidTap(feedId)):
+                case let .bottomSheet(.deleteButtonDidTap(postId)):
                     state.isShowRemovePopup = true
-                    state.feedId = feedId
+                    state.postId = postId
                     state.deleteAt = .archive
                 case let .dismissBottomSheet(feed):
                     print(feed)
@@ -194,26 +194,26 @@ struct TabBarStore: ReducerProtocol {
             case .acceptFriendship(let friend):
                 switch friend.friendType.friendshipInteraction {
                 case .follow:
-                    return friendsClient.followFriend(friend.id).map{
+                    return friendsClient.followFriend(friend.id).map {
                         Action.archive(.friends(.tappedRequestFriendDone(friend, $0)))
                     }
                 case .unfollow:
-                    return friendsClient.unfollowFriend(friend.id).map{
+                    return friendsClient.unfollowFriend(friend.id).map {
                         Action.archive(.friends(.tappedRequestFriendDone(friend, $0)))
                     }
                 }
-            case .deleteFeed:
-                guard let feedId = state.feedId else {
+            case .deletePost:
+                guard let postId = state.postId else {
                     return .none
                 }
                 
                 if state.deleteAt == .home {
-                    return feedClient.deleteFeed(feedId).map {
-                        Action.home(.deleteFeed($0))
+                    return feedClient.deletePost(postId).map {
+                        Action.home(.deletePost($0))
                     }
                 } else {
-                    return feedClient.deleteFeed(feedId).map {
-                        Action.archive(.deleteFeed($0))
+                    return feedClient.deletePost(postId).map {
+                        Action.archive(.deletePost($0))
                     }
                 }
             case .upload(.didTapPublishButtonDone(let result)):

--- a/FIMO/Sources/View/Upload/UploadStore.swift
+++ b/FIMO/Sources/View/Upload/UploadStore.swift
@@ -131,9 +131,7 @@ struct UploadStore: ReducerProtocol {
                 }
             case .didTapPublishButtonDone(let result):
                 switch result {
-                case .success(let post):
-                    Log.warning("피드, 아키이브 View 완성 시 Post 추가 Action 구현 필요")
-                    #warning("피드, 아키이브 View 완성 시 Post 추가 Action 구현 필요")
+                case .success:
                     return .init(value: .clearScene)
                 case .failure(let error):
                     return .init(value: .sendToast(ToastModel(title: error.errorDescription ?? "")))

--- a/FIMO/Sources/View/Upload/UploadStore.swift
+++ b/FIMO/Sources/View/Upload/UploadStore.swift
@@ -15,11 +15,11 @@ struct UploadStore: ReducerProtocol {
     struct State: Equatable {
         @BindingState var isIncompleteClose = false
         @BindingState var isShowImagePicker = false
-        var uploadedImages = [UploadImage]()
+        var uploadedPostItems = [FMPostItem]()
         
         @BindingState var isShowOCRErrorToast = false
         var toastMessage: ToastModel?
-        var selectedImage: UploadImage?
+        var selectedPostItem: FMPostItem?
         var isLoading: Bool = false
     }
     
@@ -31,11 +31,11 @@ struct UploadStore: ReducerProtocol {
         case didTapUploadButton
         case didTapPublishButton
         case didTapPublishButtonDone(Result<FMPostDTO, NetworkError>)
-        case didTapUploadedImage(UploadImage)
-        case didTapDeleteButton(Int)
-        case selectProfileImage(UploadImage)
-        case fetchImageUrl(UploadImage)
-        case fetchImageUrlDone(Result<ImgurImageModel, NetworkError>, UploadImage)
+        case didTapUploadedImage(FMPostItem)
+        case didTapDeleteButton(FMPostItem)
+        case selectProfileImage(UIImage)
+        case fetchImageUrl(UIImage, String)
+        case fetchImageUrlDone(Result<ImgurImageModel, NetworkError>, UIImage, String)
         case sendToast(ToastModel)
         case removeToast
     }
@@ -53,7 +53,7 @@ struct UploadStore: ReducerProtocol {
             case .clearScene:
                 state.isShowImagePicker = false
                 state.isShowOCRErrorToast = false
-                state.uploadedImages = []
+                state.uploadedPostItems = []
             case .didTapCloseButtonWithData:
                 state.isIncompleteClose = true
                 return .none
@@ -61,28 +61,20 @@ struct UploadStore: ReducerProtocol {
                 state.isShowImagePicker = true
                 
                 return .none
-            case .didTapUploadedImage(let uploadedImage):
-                state.selectedImage = uploadedImage
+            case .didTapUploadedImage(let postItem):
+                state.selectedPostItem = postItem
                 
                 return .none
-            case .didTapDeleteButton(let index):
-                state.uploadedImages = state.uploadedImages
-                    .filter { $0.id != index }
-                    .enumerated()
-                    .map({ (index, image) in
-                        var tempImage = image
-                        tempImage.id = index
-                        return tempImage
-                    })
+            case .didTapDeleteButton(let postItem):
+                state.uploadedPostItems.removeAll(where: { $0.id == postItem.id })
                 
                 return .none
             case .selectProfileImage(let uploadImage):
                 state.isLoading = true
                 let extractedText = extractText(from: uploadImage, state: &state)
-                let image = UploadImage(id: uploadImage.id, image: uploadImage.image, text: extractedText)
                 
                 if !extractedText.isEmpty {
-                    return .init(value: .fetchImageUrl(image))
+                    return .init(value: .fetchImageUrl(uploadImage, extractedText))
                 } else {
                     state.isShowOCRErrorToast = true
                     
@@ -95,22 +87,21 @@ struct UploadStore: ReducerProtocol {
                         return .sendToast(message)
                     }
                 }
-            case .fetchImageUrl(let uploadImage):
+            case .fetchImageUrl(let uploadImage, let extractedText):
                 return imgurImageClient
-                    .uploadImage(uploadImage.image.jpegData(compressionQuality: 0.9) ?? Data())
+                    .uploadImage(uploadImage.jpegData(compressionQuality: 0.9) ?? Data())
                     .map {
-                        Action.fetchImageUrlDone($0, uploadImage)
+                        Action.fetchImageUrlDone($0, uploadImage, extractedText)
                     }
-            case .fetchImageUrlDone(let result, let uploadImage):
+            case .fetchImageUrlDone(let result, let uploadImage, let extractedText):
                 switch result {
                 case .success(let imageModel):
-                    var tempUploadimage = uploadImage
-                    tempUploadimage.imageUrl = imageModel.link
+                    var postItem = FMPostItem(imageUrl: imageModel.link, content: extractedText)
 
-                    state.uploadedImages.append(tempUploadimage)
+                    state.uploadedPostItems.append(postItem)
 
-                    if state.selectedImage == nil {
-                        state.selectedImage = tempUploadimage
+                    if state.selectedPostItem == nil {
+                        state.selectedPostItem = postItem
                     }
                     state.isLoading = false
                     return .none
@@ -129,10 +120,10 @@ struct UploadStore: ReducerProtocol {
                 state.isShowOCRErrorToast = false
                 return .none
             case .didTapPublishButton:
-                let updatePost = FMUpdatedPost(items:
-                    state.uploadedImages.map({
-                        $0.toUpdatedPostItem()
-                    })
+                let updatePost = FMUpdatedPost(
+                    items: state.uploadedPostItems.map {
+                        FMUpdatedPostItem(imageUrl: $0.imageUrl, content: $0.content)
+                    }
                 )
 
                 return postClient.uploadPost(updatePost).map {
@@ -154,8 +145,8 @@ struct UploadStore: ReducerProtocol {
         }
     }
     
-    private func extractText(from image: UploadImage, state: inout State) -> String {
-        guard let convertedImage = image.image.cgImage else {
+    private func extractText(from image: UIImage, state: inout State) -> String {
+        guard let convertedImage = image.cgImage else {
             return ""
         }
         


### PR DESCRIPTION
### What is this PR?

[feature, fix] 프로필 정보 기입 유효성검사 수정, 홈, 아카이브 피드 네트워크 연결

### Changes

- 프로필 정보 기입 유효성 검사 수정
  - `sameName`, `beforeDuplicateCheck` case 추가
- 홈 아카이브 피드 네트워크 연결
  - 네이밍 혼동으로 **Feed**에 적절치 않은 네이밍은 **Post**로 변경
  - 게시물 삭제 구현
  - 게시물 수정, 업로드 진입 시 Store 올바르게 수정
  - 업로드, 수정 후 피드, 아카이브 새로고침

시간이 없어서 화면 전환(사용자 눌렀을 시 사용자 아카이브로 이동 등)은 다 못하고 여기까지 일단 진행하고 넘어가도록 하겠슴다 :)

<img width="489" alt="스크린샷 2023-07-08 오후 1 59 46" src="https://user-images.githubusercontent.com/62657991/251934054-047a3e6e-0598-4380-89c3-aa09062c419f.png">
<img width="489" alt="스크린샷 2023-07-08 오후 1 59 49" src="https://user-images.githubusercontent.com/62657991/251934064-29c09154-e7b5-4537-9a4f-77b8fcadd234.png">
<img width="489" alt="스크린샷 2023-07-08 오후 2 00 00" src="https://user-images.githubusercontent.com/62657991/251934074-c5eb0574-5073-4b91-80a4-f643c301e59a.png">

### 이후

- 서버에서 내려주는 게시글 객체에 `imageUrl`이 없어서 추가로 요청 필요
- 오늘의 새로운 게시물 관련 필드가 없음. 요청 필요